### PR TITLE
fix ghost outage instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gmailUsername   = "email.sender@gmail.com"
 gmailPassword   = "mypassword"
 ```
 
-If you have 2FA enabled on your gmail account. You will need to use an application specific password in the `gmailPassword` field. Follow the steps [here](https://myaccount.google.com/security?rapt=AEjHL4Om5qy2rzbyiFcFfbM_6SJOqxVDf6I4Bw9j9We5m7aLrn5TdXhlPSrZ4wChfQQaUyHZrt4zAHb6CYZVDbWAVgoHOb0t0w).
+If you have 2FA enabled on your gmail account. You will need to use an application specific password in the `gmailPassword` field. Follow the steps [here](https://support.google.com/mail/answer/185833?hl=en-GB).
 
 
 Create a config.json file in this directory. Below is a good default config.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ gmailUsername   = "email.sender@gmail.com"
 gmailPassword   = "mypassword"
 ```
 
+If you have 2FA enabled on your gmail account. You will need to use an application specific password in the `gmailPassword` field. Follow the steps [here](https://myaccount.google.com/security?rapt=AEjHL4Om5qy2rzbyiFcFfbM_6SJOqxVDf6I4Bw9j9We5m7aLrn5TdXhlPSrZ4wChfQQaUyHZrt4zAHb6CYZVDbWAVgoHOb0t0w).
+
+
 Create a config.json file in this directory. Below is a good default config.
 ```js
 {

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -37,10 +37,12 @@ class NodeMonitor:
         logging.info("Fetched New Data")
 
     def run_once(self):
-        diff = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
-        if diff:
+        diff_boundary = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
+        diff_adjacent = NodeMonitorDiff(self.snapshots[0], self.snapshots[1])
+        diff = DeepDiff(diff_boundary, diff_adjacent)
+        if not diff:
             logging.info("!! Change Detected")
-            events = diff.aggregate_changes()
+            events = diff_adjacent.aggregate_changes()
             events_actionable = [event for event in events
                                  if event.is_actionable()]
             email = NodeMonitorEmail(

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -23,7 +23,7 @@ from node_monitor.load_config import (
 class NodeMonitor:
 
     def __init__(self):
-        self.snapshots = deque(maxlen=2)
+        self.snapshots = deque(maxlen=3)
         if config['IMAPClientEnabled']:
             self.email_watcher_thread = threading.Thread(
                 target=email_watcher, args=(self,),
@@ -37,7 +37,7 @@ class NodeMonitor:
         logging.info("Fetched New Data")
 
     def run_once(self):
-        diff = NodeMonitorDiff(self.snapshots[0], self.snapshots[1])
+        diff = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
         if diff:
             logging.info("!! Change Detected")
             events = diff.aggregate_changes()

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -38,13 +38,17 @@ class NodeMonitor:
 
     def run_once(self):
         diff_boundary = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
-        diff_adjacent = NodeMonitorDiff(self.snapshots[0], self.snapshots[1])
-        diff = DeepDiff(diff_boundary, diff_adjacent)
-        if not diff:
+        diff_01 = NodeMonitorDiff(self.snapshots[0], self.snapshots[1])
+        diff_12 = NodeMonitorDiff(self.snapshots[1], self.snapshots[2])
+        diffs = [DeepDiff(diff_boundary, diff_01), 
+                 DeepDiff(diff_boundary, diff_12), 
+                 DeepDiff(diff_01, diff_12)]
+        all_true = all(diffs)
+        if not all_true:
             logging.info("!! Change Detected")
-            events = diff_adjacent.aggregate_changes()
+            events = diff_boundary.aggregate_changes()
             events_actionable = [event for event in events
-                                 if event.is_actionable()]
+                                if event.is_actionable()]
             email = NodeMonitorEmail(
                 "\n\n".join(str(event) for event in events_actionable)
                 + "\n\n" + self.stats_message()

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -80,7 +80,7 @@ class NodeMonitor:
     def run_once(self):
         """sends an email if status change persists for two consecutive snapshots"""
         if len(self.snapshots) != 3:
-            logging.info(f"Deque length is less than 3")
+            logging.info(f"No change - deque length is less than 3")
             return
         
         diff_ac = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -59,31 +59,44 @@ class TestNodeMonitor(unittest.TestCase):
         self.nm.snapshots.append(self.t1)
         self.nm.snapshots.append(self.t0)
         self.nm.snapshots.append(self.t1)
+        self.nm.snapshots.append(self.t0)
         self.assertEqual(self.nm.snapshots[0], self.t0)
         self.assertEqual(self.nm.snapshots[1], self.t1)
+        self.assertEqual(self.nm.snapshots[2], self.t0)
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t1)
-        nm.run_once()
+        nm.snapshots.append(self.t1)
+        nm.run_once() 
 
     @unittest.skip("sends an email")
     def test_one_node_up_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t0)
         nm.run_once()
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_two_nodes_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t2)
+        nm.run_once()
+    
+    @unittest.skip("sends an email")
+    def test_two_nodes_down_one_node_up_email(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t2)
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
         nm.run_once()
 
     @unittest.skip("sends an email")
@@ -107,21 +120,38 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once()
 
-    # @unittest.skip("shouldn't send an email")
-    def test_one_node_ghost_outage(self):
+    @unittest.skip("shouldn't send an email")
+    def test_one_node_ghost_outage_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t0)
+        nm.run_once() 
+        print("got here and didn't send and email")
+
+    @unittest.skip("sends an email")
+    def test_one_node_real_one_node_ghost_outage_email(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t2)
+        nm.snapshots.append(self.t1)
         nm.run_once() 
 
     @unittest.skip("sends an email")
-    def test_one_node_real_outage(self):
+    def test_random(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t2)
         nm.snapshots.append(self.t1)
-        nm.snapshots.append(self.t1)
-        nm.run_once() 
+        nm.run_once() # correct: email about n_eae down | current: no email
+        nm.snapshots.append(self.t0)
+        nm.run_once() # correct: email about n_eae up |
+        nm.snapshots.append(self.t0)
+        nm.run_once() # correct: no email | current: email about n1 up
+
+
+
+    
 
 
 

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -72,7 +72,7 @@ class TestNodeMonitor(unittest.TestCase):
                             self.nm.snapshots[1])
 
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
@@ -98,6 +98,9 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t2)
         nm.run_once()
 
+    # UNEXPECTED BEHAVIOR
+    # Expected behavior - send change in subnet id email
+    # Actual behavior   - send node status email
     @unittest.skip("sends an email")
     def test_one_node_change_subnet_id_email(self):
         nm = NodeMonitor()
@@ -118,7 +121,7 @@ class TestNodeMonitor(unittest.TestCase):
     def test_one_node_added_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t4)
-        nm.snapshots.append(self.t4)
+        nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t0)
         nm.run_once()
 
@@ -130,6 +133,10 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once() 
 
+    # UNDESIRED BEHAVIOR
+    # This test correctly reports the downed node (ID ending in 'eae'), 
+    # but redundantly notifies the node (ID ending in 'pae') going up. 
+    # Consider adding a config option for notifying only when a node is down.
     @unittest.skip("sends an email") 
     def test_one_node_real_one_node_ghost_outage_email(self):
         nm = NodeMonitor()

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -91,11 +91,16 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t2)
         nm.run_once()
 
+    """Test failed.
+
+    Expected behaviour: send an email about subnet change.
+    Actual behaviour: only a status email is sent.
+    """
     @unittest.skip("sends an email")
     def test_one_node_change_subnet_id_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t3)
         nm.snapshots.append(self.t3)
         nm.run_once()
 

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -45,12 +45,17 @@ class TestNodesSnapshot(unittest.TestCase):
 
 
 class TestNodeMonitor(unittest.TestCase):
-
+    # t0 = control
     t0 = NodesSnapshot.from_file("tests/t0.json")
+    # t1 = one node down
     t1 = NodesSnapshot.from_file("tests/t1.json")
+    # t2 = two nodes down
     t2 = NodesSnapshot.from_file("tests/t2.json")
+    # t3 = one node change subnet id
     t3 = NodesSnapshot.from_file("tests/t3.json")
+    # t4 = one node removed
     t4 = NodesSnapshot.from_file("tests/t4.json")
+    # t5 = node positions swapped (out of order list)
     t5 = NodesSnapshot.from_file("tests/t5.json")
 
     def test_update(self):
@@ -67,11 +72,13 @@ class TestNodeMonitor(unittest.TestCase):
                             self.nm.snapshots[1])
 
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
+        nm.run_once()
         nm.snapshots.append(self.t1)
+        nm.run_once()
         nm.snapshots.append(self.t1)
         nm.run_once() 
 
@@ -91,11 +98,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t2)
         nm.run_once()
 
-    """Test failed.
-
-    Expected behaviour: send an email about subnet change.
-    Actual behaviour: only a status email is sent.
-    """
     @unittest.skip("sends an email")
     def test_one_node_change_subnet_id_email(self):
         nm = NodeMonitor()
@@ -108,7 +110,7 @@ class TestNodeMonitor(unittest.TestCase):
     def test_one_node_removed_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t4)
         nm.snapshots.append(self.t4)
         nm.run_once()
 
@@ -128,16 +130,13 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once() 
 
-    """Test failed.
-
-    Expected behaviour: send an email that one node is really down.
-    Actual behaviour: no email sent.
-    """
-    # @unittest.skip("sends an email") 
+    @unittest.skip("sends an email") 
     def test_one_node_real_one_node_ghost_outage_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t2)
+        nm.snapshots.append(self.t1)
+        nm.run_once() 
         nm.snapshots.append(self.t1)
         nm.run_once() 
 

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -79,7 +79,7 @@ class TestNodeMonitor(unittest.TestCase):
     def test_one_node_up_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t1)
-        nm.snapshots.append(self.t1)
+        nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t0)
         nm.run_once()
 
@@ -123,7 +123,12 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once() 
 
-    @unittest.skip("sends an email")
+    """Test failed.
+
+    Expected behaviour: send an email that one node is really down.
+    Actual behaviour: no email sent.
+    """
+    # @unittest.skip("sends an email") 
     def test_one_node_real_one_node_ghost_outage_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
@@ -131,23 +136,33 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t1)
         nm.run_once() 
 
+    @unittest.skip("sends an email")
+    def test_one_node_up_long_email(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t1)
+        nm.snapshots.append(self.t1)
+        nm.snapshots.append(self.t0)
+        nm.run_once()
+        nm.snapshots.append(self.t0)
+        nm.run_once()
+        nm.snapshots.append(self.t0)
+        nm.run_once()
+
+    @unittest.skip("sends an email")
+    def test_one_node_down_long_email(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
+        nm.run_once()
+        nm.snapshots.append(self.t1)
+        nm.run_once()
+        nm.snapshots.append(self.t1)
+        nm.run_once()
 
 
 
     
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 class TestNodeMonitorEmail(unittest.TestCase):
     @unittest.skip("sends an email")

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -67,7 +67,7 @@ class TestNodeMonitor(unittest.TestCase):
                             self.nm.snapshots[1])
 
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
@@ -79,29 +79,22 @@ class TestNodeMonitor(unittest.TestCase):
     def test_one_node_up_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t1)
-        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t0)
         nm.run_once()
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_two_nodes_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t2)
-        nm.run_once()
-    
-    @unittest.skip("sends an email")
-    def test_two_nodes_down_one_node_up_email(self):
-        nm = NodeMonitor()
         nm.snapshots.append(self.t2)
-        nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t1)
         nm.run_once()
 
     @unittest.skip("sends an email")
     def test_one_node_change_subnet_id_email(self):
         nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t3)
         nm.run_once()
@@ -110,12 +103,14 @@ class TestNodeMonitor(unittest.TestCase):
     def test_one_node_removed_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t4)
         nm.run_once()
 
     @unittest.skip("sends an email")
     def test_one_node_added_email(self):
         nm = NodeMonitor()
+        nm.snapshots.append(self.t4)
         nm.snapshots.append(self.t4)
         nm.snapshots.append(self.t0)
         nm.run_once()
@@ -127,7 +122,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t0)
         nm.run_once() 
-        print("got here and didn't send and email")
 
     @unittest.skip("sends an email")
     def test_one_node_real_one_node_ghost_outage_email(self):
@@ -137,17 +131,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t1)
         nm.run_once() 
 
-    @unittest.skip("sends an email")
-    def test_random(self):
-        nm = NodeMonitor()
-        nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t2)
-        nm.snapshots.append(self.t1)
-        nm.run_once() # correct: email about n_eae down | current: no email
-        nm.snapshots.append(self.t0)
-        nm.run_once() # correct: email about n_eae up |
-        nm.snapshots.append(self.t0)
-        nm.run_once() # correct: no email | current: email about n1 up
 
 
 

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -107,14 +107,13 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once()
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("shouldn't send an email")
     def test_one_node_ghost_outage(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t1)
-        nm.run_once()
         nm.snapshots.append(self.t0)
-        nm.run_once()
+        nm.run_once() 
 
     @unittest.skip("sends an email")
     def test_one_node_real_outage(self):

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -107,6 +107,25 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once()
 
+    @unittest.skip("sends an email")
+    def test_one_node_ghost_outage(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
+        nm.run_once()
+        nm.snapshots.append(self.t0)
+        nm.run_once()
+
+    @unittest.skip("sends an email")
+    def test_one_node_real_outage(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t1)
+        nm.snapshots.append(self.t1)
+        nm.run_once() 
+
+
+
 
 
 


### PR DESCRIPTION
### Description
This PR tries to solve the "ghost outage" issue that the Node Monitor suffers from. The solution involves extending the snapshot deque to size 3. A `NodeMonitorDiff()` is done between all snapshots present in the deque, then a `DeepDiff()` is done on those diffs. If all the `DeepDiffs()`'s  return true, then there is a "ghost outage" and an email is not sent. In all other cases an email will be sent to notify the user of the changes.

### Changes Made
- Changed the deque length to 3
- Added documentation for Gmail accounts with 2FA

### Testing
- Test cases passed:
    - one node down
    - one node up 
    - two nodes down
    - one node ghost outage
- Test casses failed:
    - one node  real and one node ghost outage
    - one node change subnet
  
### Additional Notes
Could we go over the test cases that are failing during our next stand up? Also I know that the solution I propose isn't in the functional paradigm yet, but I found this was the most straight forward solution that builds off what is already there without changing things up too much. Once the diff check passes the remaining tests, I would love to spend time refactoring node monitor to see how we can write it the functional way. 

Thanks for taking the time to review this PR @mourginakis. Looking forward to your feedback!

