### PR TITLE
feat: send email only when node is down

### DIFF
--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -92,7 +92,9 @@ class NodeMonitor:
                 logging.info("!! Change Detected")
                 events = diff_ac.aggregate_changes()
                 events_actionable = [event for event in events
-                                    if event.is_actionable()]
+                                    if event.is_actionable() and event.t2 == "DOWN"]
+                print(events_actionable)
+                if len(events_actionable) == 0: return
                 email = NodeMonitorEmail(
                     "\n\n".join(str(event) for event in events_actionable)
                     + "\n\n" + self.stats_message()

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -133,10 +133,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.run_once() 
 
-    # UNDESIRED BEHAVIOR
-    # This test correctly reports the downed node (ID ending in 'eae'), 
-    # but redundantly notifies the node (ID ending in 'pae') going up. 
-    # Consider adding a config option for notifying only when a node is down.
     @unittest.skip("sends an email") 
     def test_one_node_real_one_node_ghost_outage_email(self):
         nm = NodeMonitor()


### PR DESCRIPTION
### Description
This PR is for reducing the amount of emails Node Monitor sends. More concretely, NM will only send emails when a node is down.

### Changes made
In `run_once()` I added a check to see if `self.t2 == DOWN`. Only if this is true and email is sent.

### Testing
Passes all tests in `test_node_monitor.py`.

### Additional notes
This is the "quick fix" solution that I was able to make. However, I will spend more time cutting in cutting out the code that is not needed based on the new functionality we would like NM to have.
