### PR TITLE
12 daily node status overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create a config.json file in this directory. Below is a good default config.
     "emailRecipients": ["email.receiver1@gmail.com", "email.receiver2@gmail.com"],
     "nodeProviderId": "abc2d-48fgj-32ab3-2a...",
     "intervalMinutes": 5,
+    "intervalStatusReport": 1440, 
     "lookupTableFile": "lookuptable.json",
     "NotifyOnNodeMonitorStartup": true,
     "NotifyOnNodeChangeStatus": true,
@@ -34,6 +35,7 @@ Create a config.json file in this directory. Below is a good default config.
     "IMAPClientEnabled": false
 }
 ```
+The value in `intervalStatusReport` is set in minutes. This will be the time interval in which you will receive a status report. If set, this value should always be larger than the value in `intervalMinutes`.
 
 The lookuptable.json file is mapping of node-ids to custom labels. Its use is optional.
 Example lookuptable.json:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Create a config.json file in this directory. Below is a good default config.
     "IMAPClientEnabled": false
 }
 ```
-The value in `intervalStatusReport` is set in minutes. This will be the time interval in which you will receive a status report. If set, this value should always be larger than the value in `intervalMinutes`.
+The `intervalStatusReport` value, set in minutes, determines how often you'll receive these reports. It should always be larger than the `intervalMinutes` value. If it this is not set in your config.json file, or the `intervalStatusReport` < `intervalMinutes`, you will not recieve a status report.
 
 The lookuptable.json file is mapping of node-ids to custom labels. Its use is optional.
 Example lookuptable.json:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create a .env file in this directory like so
 gmailUsername   = "email.sender@gmail.com"
 gmailPassword   = "mypassword"
 ```
+The email address listed in the `gmailUsername` field serves as the primary sender for notifications and the point of contact for getting the status of your nodes. 
 
 If you have 2FA enabled on your gmail account. You will need to use an application specific password in the `gmailPassword` field. Follow the steps [here](https://support.google.com/mail/answer/185833?hl=en-GB).
 

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -118,16 +118,22 @@ class NodeMonitor:
         status_email = NodeMonitorEmail(
             "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺" + "\n\n" + self.stats_message()
         )
-        report_interval = 60 * config['intervalStatusReport']
+
+        report_interval_set = False
+        if 'intervalStatusReport' in config and config['intervalStatusReport'] > config['intervalMinutes']:
+            report_interval = 60 * config['intervalStatusReport']
+            last_email_time = time.time()
+            report_interval_set = True
+
         api_query_interval = 60 * config['intervalMinutes']
-        last_email_time = time.time()
 
         while True:
             try:
                 self.update_state()
                 self.run_once()
                 current_time = time.time()
-                if current_time - last_email_time >= report_interval:
+                if report_interval_set and current_time - last_email_time >= report_interval:
+                    print("status email sent")
                     status_email.send_recipients(emailRecipients)
                     last_email_time = current_time
             except Exception as e:

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -133,7 +133,6 @@ class NodeMonitor:
                 self.run_once()
                 current_time = time.time()
                 if report_interval_set and current_time - last_email_time >= report_interval:
-                    print("status email sent")
                     status_email.send_recipients(emailRecipients)
                     last_email_time = current_time
             except Exception as e:

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -1,10 +1,11 @@
 import unittest
 # import os, sys
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from unittest.mock import patch, MagicMock
 from node_monitor.node_monitor import (
     NodeMonitor, NodeMonitorDiff, ChangeEvent, NodesSnapshot
 )
-from node_monitor.node_monitor_email import NodeMonitorEmail
+from node_monitor.node_monitor_email import NodeMonitorEmail, email_watcher
 from node_monitor.load_config import emailRecipients, config
 from pprint import pprint
 
@@ -345,12 +346,6 @@ class TestNodeMonitorDiff(unittest.TestCase):
     def test_node_positions_swapped(self):
         diff = NodeMonitorDiff(self.t0, self.t5)
         self.assertEqual(diff, {})
-        
-
-
-
-
-
 
 
 

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -22,14 +22,12 @@ class TestNodesSnapshot(unittest.TestCase):
         self.assertIsInstance(self.t0, list)
         self.assertIsInstance(self.t0[0], dict)
 
-
     @unittest.skip("queries api")
     def test_from_api(self):
         t1 = NodesSnapshot.from_api(
             "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae")
         self.assertIsInstance(t1, list)
         self.assertIsInstance(t1[0], dict)
-
 
     def test_get_num_up_nodes(self):
         self.assertEqual(self.t2.get_num_up_nodes(), 54)
@@ -39,10 +37,6 @@ class TestNodesSnapshot(unittest.TestCase):
 
     def test_get_num_unassigned_nodes(self):
         self.assertEqual(self.t2.get_num_unassigned_nodes(), 6)
-
-
-
-
 
 
 class TestNodeMonitor(unittest.TestCase):
@@ -72,7 +66,6 @@ class TestNodeMonitor(unittest.TestCase):
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
-
     @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
@@ -81,7 +74,7 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t1)
         nm.run_once()
         nm.snapshots.append(self.t1)
-        nm.run_once() 
+        nm.run_once()
 
     @unittest.skip("sends an email")
     def test_one_node_up_email(self):
@@ -132,17 +125,17 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t1)
         nm.snapshots.append(self.t0)
-        nm.run_once() 
+        nm.run_once()
 
-    @unittest.skip("sends an email") 
+    @unittest.skip("sends an email")
     def test_one_node_real_one_node_ghost_outage_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
         nm.snapshots.append(self.t2)
         nm.snapshots.append(self.t1)
-        nm.run_once() 
+        nm.run_once()
         nm.snapshots.append(self.t1)
-        nm.run_once() 
+        nm.run_once()
 
     @unittest.skip("sends an email")
     def test_one_node_up_long_email(self):
@@ -169,9 +162,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.run_once()
 
 
-
-    
-
 class TestNodeMonitorEmail(unittest.TestCase):
     @unittest.skip("sends an email")
     def test_send_to(self):
@@ -182,10 +172,8 @@ class TestNodeMonitorEmail(unittest.TestCase):
     def test_send_recipients(self):
         recipient1 = emailRecipients[0]
         recipient2 = emailRecipients[0]
-        NodeMonitorEmail("test email").send_recipients([recipient1, recipient2])
-
-
-
+        NodeMonitorEmail("test email").send_recipients(
+            [recipient1, recipient2])
 
 
 class TestChangeEvent(unittest.TestCase):
@@ -232,9 +220,9 @@ class TestChangeEvent(unittest.TestCase):
                 changed_parameter="status"
             )
         )
-    
+
     def test_not__ge__(self):
-        assert not ( 
+        assert not (
             ChangeEvent(
                 change_type="value_change",
                 changed_parameter="status"
@@ -249,7 +237,6 @@ class TestChangeEvent(unittest.TestCase):
         )
 
 
-
 class TestNodeMonitorDiff(unittest.TestCase):
     t0 = NodesSnapshot.from_file("tests/t0.json")
     t1 = NodesSnapshot.from_file("tests/t1.json")
@@ -261,7 +248,6 @@ class TestNodeMonitorDiff(unittest.TestCase):
     def test_diff(self):
         diff = NodeMonitorDiff(self.t0, self.t1)
         self.assertNotEqual(diff.t1, diff.t2)
-
 
     def test_one_node_down(self):
         """test one node going down"""
@@ -305,7 +291,6 @@ class TestNodeMonitorDiff(unittest.TestCase):
             )
         )
 
-
     def test_one_node_change_subnet_id(self):
         diff = NodeMonitorDiff(self.t0, self.t3)
         change_events = diff.aggregate_changes()
@@ -346,7 +331,3 @@ class TestNodeMonitorDiff(unittest.TestCase):
     def test_node_positions_swapped(self):
         diff = NodeMonitorDiff(self.t0, self.t5)
         self.assertEqual(diff, {})
-
-
-
-


### PR DESCRIPTION
### Description
This PR makes node monitor send status report emails at a user defined interval. If `intervalStatusReport` is set in the config.json file, and `intervalStatusReport` < 'intervalMinutes', Node Monitor will NOT send the status report.

### Changes made
- `runloop()` is where most of the changes are made. 
- updates to the readme file for the new key.

### Testing
Tested manually via print statements and checking my email.

### Additional notes
n/a
