### PR TITLE
Slack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Create a config.json file in this directory. Below is a good default config.
 ```js
 {
     "emailRecipients": ["email.receiver1@gmail.com", "email.receiver2@gmail.com"],
+    "slackChannelName": "node-monitor",
     "nodeProviderId": "abc2d-48fgj-32ab3-2a...",
     "intervalMinutes": 5,
     "intervalStatusReport": 1440, 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Create a config.json file in this directory. Below is a good default config.
     "NotifyOnAllNodeChanges": false,
     "NotifyOnNodeAdded": true,
     "NotifyOnNodeRemoved": true,
-    "IMAPClientEnabled": false
+    "IMAPClientEnabled": false,
+    "NotifyBySlack": true,
+    "NotifyByEmail": true
 }
 ```
 The `intervalStatusReport` value, set in minutes, determines how often you'll receive these reports. It should always be larger than the `intervalMinutes` value. If it this is not set in your config.json file, or the `intervalStatusReport` < `intervalMinutes`, you will not recieve a status report.

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -1,23 +1,25 @@
 from datetime import datetime, timezone
 from dotenv import load_dotenv
-import os, json
+import os
+import json
 import logging
 
 
-### Secrets
+# Secrets
 load_dotenv()
-gmailUsername       = os.environ.get('gmailUsername')
-gmailPassword       = os.environ.get('gmailPassword')
-discordBotToken     = os.environ.get('discordBotToken')  # Not implemented
-slackBotToken       = os.environ.get('slackBotToken')
+gmailUsername = os.environ.get('gmailUsername')
+gmailPassword = os.environ.get('gmailPassword')
+discordBotToken = os.environ.get('discordBotToken')  # Not implemented
+slackBotToken = os.environ.get('slackBotToken')
 
 
-### Config File
+# Config File
 with open("config.json") as f:
     config = json.load(f)
     emailRecipients = config['emailRecipients']
-    nodeProviderId  = config['nodeProviderId']
+    nodeProviderId = config['nodeProviderId']
     lookupTableFile = config['lookupTableFile']
+    slackChannelName = config['slackChannelName']
 
 # config['intervalMinutes']
 # config['NotifyOnNodeMonitorStartup']
@@ -27,15 +29,14 @@ with open("config.json") as f:
 # config['NotifyOnNodeRemoved']
 # config['IMAPClientEnabled']
 
-### Lookup Table
+# Lookup Table
 lookuptable = {}
 if lookupTableFile != "":
     with open(lookupTableFile) as f:
         lookuptable = json.load(f)
 
 
-## Logging - use systemd to forward stdout/stderr to journald
+# Logging - use systemd to forward stdout/stderr to journald
 logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper(),
                     format='%(asctime)s:%(levelname)s:%(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S')
-

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -9,6 +9,7 @@ load_dotenv()
 gmailUsername       = os.environ.get('gmailUsername')
 gmailPassword       = os.environ.get('gmailPassword')
 discordBotToken     = os.environ.get('discordBotToken')  # Not implemented
+slackBotToken       = os.environ.get('slackBotToken')
 
 
 ### Config File

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -15,7 +15,7 @@ import typing
 from node_monitor.node_monitor_email import NodeMonitorEmail, email_watcher
 from node_monitor.slack_bot import SlackBot
 from node_monitor.load_config import (
-    nodeProviderId, emailRecipients, config, lookuptable, slackBotToken
+    nodeProviderId, emailRecipients, config, lookuptable,
 )
 
 #   --- diff_ac ---

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -96,14 +96,8 @@ class NodeMonitor:
                                      if event.is_actionable() and event.t2 == "DOWN"]
                 if len(events_actionable) == 0:
                     return
-                email = NodeMonitorEmail(
-                    "\n\n".join(str(event) for event in events_actionable)
-                    + "\n\n" + self.stats_message()
-                )
-                email.send_recipients(emailRecipients)
-                SlackBot().send_message(
-                    "\n\n".join(str(event) for event in events_actionable) 
-                    + "\n\n" + self.stats_message())
+                message = "\n\n".join(str(event) for event in events_actionable) + "\n\n" + self.stats_message()
+                self.send_to_apps(message)
                 logging.info("Emails Sent")
                 return
 
@@ -169,6 +163,13 @@ class NodeMonitor:
             f"There are currently {self.snapshots[-1].get_num_down_nodes()} nodes in 'DOWN' status.\n"
             f"There are currently {self.snapshots[-1].get_num_unassigned_nodes()} nodes in 'UNASSIGNED' status.\n\n"
         )
+    
+    def send_to_apps(self, message):
+        email = NodeMonitorEmail(message)
+        email.send_recipients(emailRecipients)
+        SlackBot().send_message(message)
+        return
+
 
     # possible diff keys (scraped from source):
     # 'set_item_added', 'set_item_removed', 'iterable_item_removed'

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -83,8 +83,6 @@ class NodeMonitor:
         if len(self.snapshots) != 3:
             logging.info(f"No change - deque length is less than 3")
             return
-        
-        SlackBot().send_message("Hello world")
 
         diff_ac = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
         match categorize_deque(self.snapshots):
@@ -103,6 +101,9 @@ class NodeMonitor:
                     + "\n\n" + self.stats_message()
                 )
                 email.send_recipients(emailRecipients)
+                SlackBot().send_message(
+                    "\n\n".join(str(event) for event in events_actionable) 
+                    + "\n\n" + self.stats_message())
                 logging.info("Emails Sent")
                 return
 

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -165,9 +165,11 @@ class NodeMonitor:
         )
     
     def send_to_apps(self, message):
-        email = NodeMonitorEmail(message)
-        email.send_recipients(emailRecipients)
-        SlackBot().send_message(message)
+        if config['NotifyByEmail']:
+            email = NodeMonitorEmail(message)
+            email.send_recipients(emailRecipients)
+        if config['NotifyBySlack']:
+            SlackBot().send_message(message)
         return
 
 

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -96,8 +96,9 @@ class NodeMonitor:
                                      if event.is_actionable() and event.t2 == "DOWN"]
                 if len(events_actionable) == 0:
                     return
-                message = "\n\n".join(str(event) for event in events_actionable) + "\n\n" + self.stats_message()
-                self.send_to_apps(message)
+                message = "\n\n".join(
+                    str(event) for event in events_actionable) + "\n\n" + self.stats_message()
+                self.send_to_subscribers(message)
                 logging.info("Emails Sent")
                 return
 
@@ -107,15 +108,10 @@ class NodeMonitor:
         self.update_state()
 
         if config['NotifyOnNodeMonitorStartup']:
-            welcome_email = NodeMonitorEmail(
+            self.send_to_subscribers(
                 self.welcome_message() + self.stats_message())
-            welcome_email.send_recipients(emailRecipients)
 
         signal.signal(signal.SIGINT, lambda s, f: self.exit())
-
-        status_email = NodeMonitorEmail(
-            "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺" + "\n\n" + self.stats_message()
-        )
 
         report_interval_set = False
         if 'intervalStatusReport' in config and config['intervalStatusReport'] > config['intervalMinutes']:
@@ -131,7 +127,8 @@ class NodeMonitor:
                 self.run_once()
                 current_time = time.time()
                 if report_interval_set and current_time - last_email_time >= report_interval:
-                    status_email.send_recipients(emailRecipients)
+                    self.send_to_subscribers(
+                        "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺" + "\n\n" + self.stats_message())
                     last_email_time = current_time
             except Exception as e:
                 logging.exception(e)
@@ -151,10 +148,13 @@ class NodeMonitor:
             f"Thank you for subscribing to Node Monitor by Aviate Labs!\n"
             f"Your Node Monitor Settings:\n"
             f"\t ► Dfinity API query update interval: {config['intervalMinutes']} minutes\n"
-            f"\t ► Send Email on Node Change status (UP, DOWN, UNASSIGNED): {config['NotifyOnNodeChangeStatus']}\n"
-            f"\t ► Send Email on Any Node update (verbose mode): {config['NotifyOnAllNodeChanges']}\n"
-            f"\t ► Send Email if new node appears on network: {config['NotifyOnNodeAdded']}\n"
-            f"\t ► Send Email if node gets removed from network: {config['NotifyOnNodeRemoved']}\n"
+            f"\t ► Send notifications via Email: {config['NotifyByEmail']}\n"
+            f"\t ► Send notifications via Slack: {config['NotifyBySlack']}\n"
+            f"\t ► Send notification on Node Change status (UP, DOWN, UNASSIGNED): {config['NotifyOnNodeChangeStatus']}\n"
+            f"\t ► Send notification on Any Node update (verbose mode): {config['NotifyOnAllNodeChanges']}\n"
+            f"\t ► Send notification if new node appears on network: {config['NotifyOnNodeAdded']}\n"
+            f"\t ► Send notification if node gets removed from network: {config['NotifyOnNodeRemoved']}\n"
+            f"\t ► Send status report based on this interval (minutes): {config['intervalMinutes']}\n"
         )
 
     def stats_message(self):
@@ -163,15 +163,14 @@ class NodeMonitor:
             f"There are currently {self.snapshots[-1].get_num_down_nodes()} nodes in 'DOWN' status.\n"
             f"There are currently {self.snapshots[-1].get_num_unassigned_nodes()} nodes in 'UNASSIGNED' status.\n\n"
         )
-    
-    def send_to_apps(self, message):
+
+    def send_to_subscribers(self, message):
         if config['NotifyByEmail']:
             email = NodeMonitorEmail(message)
             email.send_recipients(emailRecipients)
         if config['NotifyBySlack']:
             SlackBot().send_message(message)
         return
-
 
     # possible diff keys (scraped from source):
     # 'set_item_added', 'set_item_removed', 'iterable_item_removed'

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -96,8 +96,10 @@ class NodeMonitor:
                                      if event.is_actionable() and event.t2 == "DOWN"]
                 if len(events_actionable) == 0:
                     return
-                message = "\n\n".join(
-                    str(event) for event in events_actionable) + "\n\n" + self.stats_message()
+                message = (
+                    "\n\n".join(str(event) for event in events_actionable)
+                    + "\n\n"
+                    + self.stats_message())
                 self.send_to_subscribers(message)
                 logging.info("Emails Sent")
                 return

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -13,8 +13,9 @@ import typing
 
 
 from node_monitor.node_monitor_email import NodeMonitorEmail, email_watcher
+from node_monitor.slack_bot import SlackBot
 from node_monitor.load_config import (
-    nodeProviderId, emailRecipients, config, lookuptable
+    nodeProviderId, emailRecipients, config, lookuptable, slackBotToken
 )
 
 #   --- diff_ac ---
@@ -82,6 +83,8 @@ class NodeMonitor:
         if len(self.snapshots) != 3:
             logging.info(f"No change - deque length is less than 3")
             return
+        
+        SlackBot().send_message("Hello world")
 
         diff_ac = NodeMonitorDiff(self.snapshots[0], self.snapshots[2])
         match categorize_deque(self.snapshots):

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -6,14 +6,10 @@ from node_monitor.load_config import slackBotToken
 class SlackBot():
     def __init__(self):
         self.client = slack.WebClient(token=slackBotToken)
-    
+
     def send_message(self, message_content):
-        self.client.chat_postMessage(channel='#node-monitor', text=message_content)
+        self.client.chat_postMessage(
+            channel='#node-monitor', text=message_content)
 
 
-
-
-# client = slack.WebClient(token=slackBotToken)
-
-# client.chat_postMessage(channel='#node-monitor', text="Hello world!")
-
+# TODO: allow slack bot to monitor chat for "status message"

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -1,6 +1,6 @@
 import slack
-from dotenv import load_dotenv
-from node_monitor.load_config import slackBotToken
+import logging
+from node_monitor.load_config import slackBotToken, slackChannelName
 
 
 class SlackBot():
@@ -8,8 +8,13 @@ class SlackBot():
         self.client = slack.WebClient(token=slackBotToken)
 
     def send_message(self, message_content):
-        self.client.chat_postMessage(
-            channel='#node-monitor', text=message_content)
+        try:
+            self.client.chat_postMessage(
+                channel=slackChannelName, text=message_content)
+        except Exception as e:
+            # logging.exception(e)
+            logging.info(
+                f"Error occurred while sending Slack message. Check that the name of the Slack channel is correct")
 
 
 # TODO: allow slack bot to monitor chat for "status message"

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -1,11 +1,19 @@
 import slack
-import os
-from pathlib import Path
 from dotenv import load_dotenv
+from node_monitor.load_config import slackBotToken
 
-env_path = Path('.') / '.env'
-load_dotenv(dotenv_path=env_path)
 
-client = slack.WebClient(token=os.environ['slackToken'])
+class SlackBot():
+    def __init__(self):
+        self.client = slack.WebClient(token=slackBotToken)
+    
+    def send_message(self, message_content):
+        self.client.chat_postMessage(channel='#node-monitor', text=message_content)
 
-client.chat_postMessage(channel='#node-monitor', text="Hello world!")
+
+
+
+# client = slack.WebClient(token=slackBotToken)
+
+# client.chat_postMessage(channel='#node-monitor', text="Hello world!")
+

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -1,0 +1,11 @@
+import slack
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+env_path = Path('.') / '.env'
+load_dotenv(dotenv_path=env_path)
+
+client = slack.WebClient(token=os.environ['slackToken'])
+
+client.chat_postMessage(channel='#node-monitor', text="Hello world!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ deepdiff6
 discord.py
 python-dotenv
 requests
+slackclient

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -66,7 +66,7 @@ class TestNodeMonitor(unittest.TestCase):
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)
@@ -108,7 +108,7 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t4)
         nm.run_once()
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_one_node_added_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t4)

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -1,11 +1,11 @@
 import unittest
 # import os, sys
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from unittest.mock import patch, MagicMock
 from node_monitor.node_monitor import (
     NodeMonitor, NodeMonitorDiff, ChangeEvent, NodesSnapshot
 )
-from node_monitor.node_monitor_email import NodeMonitorEmail, email_watcher
+from node_monitor.node_monitor_email import NodeMonitorEmail
+from node_monitor.slack_bot import SlackBot
 from node_monitor.load_config import emailRecipients, config
 from pprint import pprint
 
@@ -160,6 +160,15 @@ class TestNodeMonitor(unittest.TestCase):
         nm.run_once()
         nm.snapshots.append(self.t1)
         nm.run_once()
+
+    # @unittest.skip("sends an email")
+    def test_hello_world_slack(self):
+        nm = NodeMonitor()
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t0)
+        nm.snapshots.append(self.t0)
+        nm.run_once()
+
 
 
 class TestNodeMonitorEmail(unittest.TestCase):

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -92,9 +92,6 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t2)
         nm.run_once()
 
-    # UNEXPECTED BEHAVIOR
-    # Expected behavior - send change in subnet id email
-    # Actual behavior   - send node status email
     @unittest.skip("sends an email")
     def test_one_node_change_subnet_id_email(self):
         nm = NodeMonitor()
@@ -161,14 +158,11 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t1)
         nm.run_once()
 
-    # @unittest.skip("sends an email")
-    def test_hello_world_slack(self):
-        nm = NodeMonitor()
-        nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t0)
-        nm.snapshots.append(self.t0)
-        nm.run_once()
 
+class TestNodeMonitorSlackBot(unittest.TestCase):
+    @unittest.skip("sends an email")
+    def test_hello_world_slack(self):
+        SlackBot().send_message("test message on slack")
 
 
 class TestNodeMonitorEmail(unittest.TestCase):

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -108,7 +108,7 @@ class TestNodeMonitor(unittest.TestCase):
         nm.snapshots.append(self.t4)
         nm.run_once()
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_one_node_added_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t4)

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -66,7 +66,7 @@ class TestNodeMonitor(unittest.TestCase):
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)


### PR DESCRIPTION
### Description
This PR is for the Slack integration. Now, NM can send notifications to a user defined slack channel, as well as the interval based status reports.

### Changes made
- `slack_bot`.py - contains the slack bot class. This class will be extended when we add more features to what the slack bot can do.
- Added function `send_to_subscribers()` in `node_monitor.py`. This is where additional integrations can be put so that NM can just call a single function, and depending on the user config, the message will be sent to all channels that are subscribed.

### Testing
Manual testing. @mourginakis I am curious to know how you would approach this in a TDD way.

### Additional notes
The current slack integration can only notify the slack channel. It does not listen to the channel yet. This means that the on-demand status report feature that is available on email is not yet available on slack. Main reason is because it involves spinning up a web-server within node monitor. This will require additional research but it did not have to block this feature, which is why this will be implemented in a separate PR.

The readme file will also need to be updated to show how a user can perform the steps to set up the slack bot on their end.

Thanks for reviewing this @mourginakis !