### PR TITLE
23 telegram integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a .env file in this directory like so
 gmailUsername       = "email.sender@gmail.com"
 gmailPassword       = "mypassword"
 slackBotToken       = "your-slack-bot-api-token"
-telegramBotToken    = "your=telegram-bot-api-token"
+telegramBotToken    = "your-telegram-bot-api-token"
 ```
 The email address listed in the `gmailUsername` field serves as the primary sender for notifications and the point of contact for getting the status of your nodes. 
 
@@ -114,9 +114,25 @@ $ curl "https://ic-api.internetcomputer.org/api/v3/nodes" -o t0.json
 
 ## Set up Node Monitor Slack Bot
 
-- Follow the steps in this [walkthrough](https://app.tango.us/app/workflow/Setting-up-a-Node-Monitor-Bot-in-Slack--Step-by-Step-Instructions-c971a31e13a344dc8cba4c2ebc3f4e4e)
+- Follow the steps in this [walkthrough](https://app.tango.us/app/workflow/Setting-up-a-Node-Monitor-Bot-in-Slack--Step-by-Step-Instructions-c971a31e13a344dc8cba4c2ebc3f4e4e).
 
-- After following the steps in this tutorial you should have the bot API token and the channel name (step 24 and 29)
+- After following the steps in this tutorial you should have the bot API token and the channel name (step 24 and 29).
 
-- Put the bot API token in the `.env` file and the channel name in the `config.json` file.
+- Put the bot API token in the `.env` file in the `slackBotToken` field and the channel name in the `config.json` file in the `slackChannelName` field.
 
+## Set up Node Monitor Telegram bot
+
+### Messaging a channel 
+- Follow the steps in this [walkthrough](https://help.nethunt.com/en/articles/6467726-how-to-create-a-telegram-bot-and-use-it-to-post-in-telegram-channels)
+
+- After following the steps in the tutorial, you should have a bot API token and the channel ID. Put the bot API token in the `.env` file in the `telegramBotToken` field and the channel ID in the `config.json` file in the `telegramChanelId` field.
+
+### Messaging a chat 
+- Follow the same steps as in the tutorial for messaging a channel.
+
+- In step 3, look for your chat ID. It should look something like:
+    ```json
+    'chat': {'id': this-is-your-chat-id, ...}
+    ```
+
+- Now you have the bot API token and the chat ID, put the bot API token in the `.env` file in the `telegramBotToken` field and the chat ID in the `config.json` file in the `telegramChatId` field.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Create a config.json file in this directory. Below is a good default config.
 {
     "emailRecipients": ["email.receiver1@gmail.com", "email.receiver2@gmail.com"],
     "slackChannelName": "node-monitor",
+    "telegramChatId": "0123456789",
+    "telegramChannelId": "-1234567890987",
     "nodeProviderId": "abc2d-48fgj-32ab3-2a...",
     "intervalMinutes": 5,
     "intervalStatusReport": 1440, 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Includes an optional feature to send a status update to any incoming emails that
 ## Setup
 Create a .env file in this directory like so
 ```text
-gmailUsername   = "email.sender@gmail.com"
-gmailPassword   = "mypassword"
+gmailUsername       = "email.sender@gmail.com"
+gmailPassword       = "mypassword"
+slackBotToken       = "your-slack-bot-api-token"
+telegramBotToken    = "your=telegram-bot-api-token"
 ```
 The email address listed in the `gmailUsername` field serves as the primary sender for notifications and the point of contact for getting the status of your nodes. 
 
@@ -23,7 +25,7 @@ Create a config.json file in this directory. Below is a good default config.
 ```js
 {
     "emailRecipients": ["email.receiver1@gmail.com", "email.receiver2@gmail.com"],
-    "slackChannelName": "node-monitor",
+    "slackChannelName": "your-node-monitor-channel",
     "telegramChatId": "0123456789",
     "telegramChannelId": "-1234567890987",
     "nodeProviderId": "abc2d-48fgj-32ab3-2a...",
@@ -109,4 +111,12 @@ $ curl "https://ic-api.internetcomputer.org/api/v3/nodes" -o t0.json
 - NotifyOnNodeRemoved: Send an email when a node is removed from the dashboard API
 
 - IMAPClientEnabled: Watch inbox and send any responses to emails querying a status update
+
+## Set up Node Monitor Slack Bot
+
+- Follow the steps in this [walkthrough](https://app.tango.us/app/workflow/Setting-up-a-Node-Monitor-Bot-in-Slack--Step-by-Step-Instructions-c971a31e13a344dc8cba4c2ebc3f4e4e)
+
+- After following the steps in this tutorial you should have the bot API token and the channel name (step 24 and 29)
+
+- Put the bot API token in the `.env` file and the channel name in the `config.json` file.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ $ curl "https://ic-api.internetcomputer.org/api/v3/nodes" -o t0.json
 
 - IMAPClientEnabled: Watch inbox and send any responses to emails querying a status update
 
+- NotfyBySlack: Sends Slack messages according to the settings specified above
+
+- NotifyByTelegram: Sends Telegram messages according to the settings specified above
+
 ## Set up Node Monitor Slack Bot
 
 - Follow the steps in this [walkthrough](https://app.tango.us/app/workflow/Setting-up-a-Node-Monitor-Bot-in-Slack--Step-by-Step-Instructions-c971a31e13a344dc8cba4c2ebc3f4e4e).

--- a/node_monitor/discord_bot.py
+++ b/node_monitor/discord_bot.py
@@ -1,4 +1,4 @@
-import discord
+spimport discord
 
 class DiscordBot(discord.Client):
     async def on_ready(self):

--- a/node_monitor/discord_bot.py
+++ b/node_monitor/discord_bot.py
@@ -1,4 +1,5 @@
-spimport discord
+import discord
+
 
 class DiscordBot(discord.Client):
     async def on_ready(self):
@@ -7,7 +8,7 @@ class DiscordBot(discord.Client):
     async def on_message(self, message):
         if message.author.id == self.user.id:
             return
-        
+
         if message.content.startswith("$list"):
             await message.channel.send("nothing to list")
 
@@ -20,9 +21,3 @@ def run_bot(token):
     intents.message_content = True
     discordbot = DiscordBot(intents=intents)
     discordbot.run(token)
-
-
-
-
-
-

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -7,21 +7,22 @@ import logging
 
 # Secrets
 load_dotenv()
-gmailUsername = os.environ.get('gmailUsername')
-gmailPassword = os.environ.get('gmailPassword')
-discordBotToken = os.environ.get('discordBotToken')  # Not implemented
-slackBotToken = os.environ.get('slackBotToken')
-telegramBotToken = os.environ.get('telegramBotToken')
+gmailUsername       = os.environ.get('gmailUsername')
+gmailPassword       = os.environ.get('gmailPassword')
+discordBotToken     = os.environ.get('discordBotToken')  # Not implemented
+slackBotToken       = os.environ.get('slackBotToken')
+telegramBotToken    = os.environ.get('telegramBotToken')
 
 
 # Config File
 with open("config.json") as f:
     config = json.load(f)
-    emailRecipients = config['emailRecipients']
-    nodeProviderId = config['nodeProviderId']
-    lookupTableFile = config['lookupTableFile']
-    slackChannelName = config['slackChannelName']
-    telegramChatId = config['telegramChatId']
+    emailRecipients     = config['emailRecipients']
+    nodeProviderId      = config['nodeProviderId']
+    lookupTableFile     = config['lookupTableFile']
+    slackChannelName    = config['slackChannelName']
+    telegramChatId      = config['telegramChatId']
+    telegramChannelId   = config['telegramChannelId']
 
 # config['intervalMinutes']
 # config['NotifyOnNodeMonitorStartup']

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -11,6 +11,7 @@ gmailUsername = os.environ.get('gmailUsername')
 gmailPassword = os.environ.get('gmailPassword')
 discordBotToken = os.environ.get('discordBotToken')  # Not implemented
 slackBotToken = os.environ.get('slackBotToken')
+telegramBotToken = os.environ.get('telegramBotToken')
 
 
 # Config File
@@ -20,6 +21,7 @@ with open("config.json") as f:
     nodeProviderId = config['nodeProviderId']
     lookupTableFile = config['lookupTableFile']
     slackChannelName = config['slackChannelName']
+    telegramChatId = config['telegramChatId']
 
 # config['intervalMinutes']
 # config['NotifyOnNodeMonitorStartup']

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -133,6 +133,7 @@ class NodeMonitor:
                     self.send_to_subscribers(
                         "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺" + "\n\n" + self.stats_message())
                     last_email_time = current_time
+                    logging.info("Send status report")
             except Exception as e:
                 logging.exception(e)
                 logging.info("Error occurred. Retrying...")
@@ -173,8 +174,10 @@ class NodeMonitor:
             email.send_recipients(emailRecipients)
         if config['NotifyBySlack']:
             SlackBot().send_message(message)
-        if config['NotifyByTelegram']:
+        if config['NotifyByTelegramChannel']:
             TelegramBot().send_message_to_channel(message)
+        if config['NotifyByTelegramChat']:
+            TelegramBot().send_message_to_chat(message)
         return
 
     # possible diff keys (scraped from source):

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -131,7 +131,9 @@ class NodeMonitor:
                 current_time = time.time()
                 if report_interval_set and current_time - last_email_time >= report_interval:
                     self.send_to_subscribers(
-                        "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺" + "\n\n" + self.stats_message())
+                        "🩺🩺🩺 NODE STATUS REPORT 🩺🩺🩺"
+                        + "\n\n"
+                        + self.stats_message())
                     last_email_time = current_time
                     logging.info("Send status report")
             except Exception as e:

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -14,6 +14,7 @@ import typing
 
 from node_monitor.node_monitor_email import NodeMonitorEmail, email_watcher
 from node_monitor.slack_bot import SlackBot
+from node_monitor.telegram_bot import TelegramBot
 from node_monitor.load_config import (
     nodeProviderId, emailRecipients, config, lookuptable,
 )
@@ -172,6 +173,8 @@ class NodeMonitor:
             email.send_recipients(emailRecipients)
         if config['NotifyBySlack']:
             SlackBot().send_message(message)
+        if config['NotifyByTelegram']:
+            TelegramBot().send_message_to_channel(message)
         return
 
     # possible diff keys (scraped from source):

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -177,9 +177,9 @@ class NodeMonitor:
         if config['NotifyBySlack']:
             SlackBot().send_message(message)
         if config['NotifyByTelegramChannel']:
-            TelegramBot().send_message_to_channel(message)
+            TelegramBot.send_message_to_channel(message)
         if config['NotifyByTelegramChat']:
-            TelegramBot().send_message_to_chat(message)
+            TelegramBot.send_message_to_chat(message)
         return
 
     # possible diff keys (scraped from source):

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -14,7 +14,7 @@ class SlackBot():
         except Exception as e:
             # logging.exception(e)
             logging.info(
-                f"Error occurred while sending Slack message. Check that the name of the Slack channel is correct")
+                f"Error occurred while sending Slack message. Check that the name of the Slack channel and/or bot API token is correct")
 
 
 # TODO: allow slack bot to monitor chat for "status message"

--- a/node_monitor/slack_bot.py
+++ b/node_monitor/slack_bot.py
@@ -14,7 +14,9 @@ class SlackBot():
         except Exception as e:
             # logging.exception(e)
             logging.info(
-                f"Error occurred while sending Slack message. Check that the name of the Slack channel and/or bot API token is correct")
+                f"Error occurred while sending Slack message. " 
+                f"Check the name of the Slack channel and/or bot API token is correct"
+            )
 
 
 # TODO: allow slack bot to monitor chat for "status message"

--- a/node_monitor/telegram_bot.py
+++ b/node_monitor/telegram_bot.py
@@ -4,7 +4,8 @@ from node_monitor.load_config import telegramBotToken, telegramChatId, telegramC
 
 
 class TelegramBot():
-    def send_message_to_channel(self, message_content):
+    @staticmethod
+    def send_message_to_channel(message_content):
         try:
             request = requests.get(
                 f"https://api.telegram.org/bot{telegramBotToken}"
@@ -18,7 +19,8 @@ class TelegramBot():
                 f"Check that the Telegram channel id and/or Telegram bot API token is correct"
             )
 
-    def send_message_to_chat(self, message_content):
+    @staticmethod
+    def send_message_to_chat(message_content):
         try:
             request = requests.get(
                 f"https://api.telegram.org/bot{telegramBotToken}"

--- a/node_monitor/telegram_bot.py
+++ b/node_monitor/telegram_bot.py
@@ -12,7 +12,7 @@ class TelegramBot():
         except requests.exceptions.HTTPError as e:
             # logging.error(e)
             logging.error(
-                f"Error occurred while sending Telegram message. Check that the name of the Telegram channel id is correct")
+                f"Error occurred while sending Telegram message. Check that the name of the Telegram channel id and/or Telegram Bot API token is correct")
 
     def send_message_to_chat(self, message_content):
         try:
@@ -22,4 +22,4 @@ class TelegramBot():
         except Exception as e:
             # logging.error(e)
             logging.error(
-                f"Error occurred while sending Telegram message. Check that the name of the Telegram chat id is correct")
+                f"Error occurred while sending Telegram message. Check that the name of the Telegram chat id and/or Telegram Bot API token is correct")

--- a/node_monitor/telegram_bot.py
+++ b/node_monitor/telegram_bot.py
@@ -1,0 +1,25 @@
+import requests
+import logging
+from node_monitor.load_config import telegramBotToken, telegramChatId, telegramChannelId
+
+
+class TelegramBot():
+    def send_message_to_channel(self, message_content):
+        try:
+            request = requests.get(
+                f"https://api.telegram.org/bot{telegramBotToken}/sendMessage?chat_id={telegramChannelId}&text={message_content}")
+            request.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            # logging.error(e)
+            logging.error(
+                f"Error occurred while sending Telegram message. Check that the name of the Telegram channel id is correct")
+
+    def send_message_to_chat(self, message_content):
+        try:
+            request = requests.get(
+                f"https://api.telegram.org/bot{telegramBotToken}/sendMessage?chat_id={telegramChatId}&text={message_content}")
+            request.raise_for_status()
+        except Exception as e:
+            # logging.error(e)
+            logging.error(
+                f"Error occurred while sending Telegram message. Check that the name of the Telegram chat id is correct")

--- a/node_monitor/telegram_bot.py
+++ b/node_monitor/telegram_bot.py
@@ -7,19 +7,27 @@ class TelegramBot():
     def send_message_to_channel(self, message_content):
         try:
             request = requests.get(
-                f"https://api.telegram.org/bot{telegramBotToken}/sendMessage?chat_id={telegramChannelId}&text={message_content}")
+                f"https://api.telegram.org/bot{telegramBotToken}"
+                f"/sendMessage?chat_id={telegramChannelId}&text={message_content}"
+            )
             request.raise_for_status()
         except requests.exceptions.HTTPError as e:
             # logging.error(e)
             logging.error(
-                f"Error occurred while sending Telegram message. Check that the name of the Telegram channel id and/or Telegram Bot API token is correct")
+                f"Error occurred while sending Telegram message. "
+                f"Check that the Telegram channel id and/or Telegram bot API token is correct"
+            )
 
     def send_message_to_chat(self, message_content):
         try:
             request = requests.get(
-                f"https://api.telegram.org/bot{telegramBotToken}/sendMessage?chat_id={telegramChatId}&text={message_content}")
+                f"https://api.telegram.org/bot{telegramBotToken}"
+                f"/sendMessage?chat_id={telegramChatId}&text={message_content}"
+            )
             request.raise_for_status()
         except Exception as e:
             # logging.error(e)
             logging.error(
-                f"Error occurred while sending Telegram message. Check that the name of the Telegram chat id and/or Telegram Bot API token is correct")
+                f"Error occurred while sending Telegram message. "
+                f"Check that the Telegram chat id and/or Telegram bot API token is correct"
+            )

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -66,7 +66,7 @@ class TestNodeMonitor(unittest.TestCase):
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
-    # @unittest.skip("sends an email")
+    @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -66,7 +66,7 @@ class TestNodeMonitor(unittest.TestCase):
         self.assertNotEqual(self.nm.snapshots[0],
                             self.nm.snapshots[1])
 
-    @unittest.skip("sends an email")
+    # @unittest.skip("sends an email")
     def test_one_node_down_email(self):
         nm = NodeMonitor()
         nm.snapshots.append(self.t0)


### PR DESCRIPTION
### Description
This PR allows node monitor to send notifications via Telegram. 

### Changes Made
- `node_monitor/telegram_bot` holds the `TelegramBot` class which can send messages to either a channel, or directly to the user.
- extra if statements were added in `send_to_subscirbers()` to handle messages to telegram channels and to the telegram chat.
- example config in the readme

### Testing
Manual testing was done by having NM send messages to my personal telegram account. @mourginakis If you have suggestions on better ways to test the code, I'm all ears!

- sending node down messages ✅
- sending interval based status reports ✅

### Additional comments
I still need to update the readme of the repo with guides on how to set up the slack bot and telegram bot from the users side.

Also, similar to the slack bot, telegram does not yet listen to the chats for the status message. This will be implemented in a separate PR later on.
