### PR TITLE
refactor: capitalize variables in .env and generalize variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-gmailUsername = "example_email@gmail.com"
-gmailPassword = "example_password"
-discordBotToken = "discord_token_example"
+EMAIL_USERNAME = "example_email@gmail.com"
+EMAIL_PASSWORD = "example_password"
+TOKEN_DISCORD = "discord_token_example"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Create fake .env file to pass assertions
         run: |
           touch .env
-          echo "gmailUsername=test@email.com" >> .env
-          echo "gmailPassword=testPassword" >> .env
+          echo "EMAIL_USERNAME=test@email.com" >> .env
+          echo "EMAIL_PASSWORD=testPassword" >> .env
 
 
       - name: Build and Test Docker Container

--- a/node_monitor/__main__.py
+++ b/node_monitor/__main__.py
@@ -8,7 +8,7 @@ import node_monitor.load_config as c
 ## Initialize
 ## Objects are passed by reference, so we can pass around the NodeMonitor
 ## instance and work on the same data in different functions/threads
-email_bot = EmailBot(c.gmailUsername, c.gmailPassword)
+email_bot = EmailBot(c.EMAIL_USERNAME, c.EMAIL_PASSWORD)
 nm = NodeMonitor(email_bot)
 
 

--- a/node_monitor/bot_email.py
+++ b/node_monitor/bot_email.py
@@ -5,13 +5,13 @@ from typing import List
 
 class EmailBot:
     def __init__(
-            self, gmail_username: str, gmail_password: str, 
+            self, email_username: str, email_password: str, 
             smtp_server: str = 'smtp.gmail.com', smtp_port: int = 587) -> None:
         """Create an EmailBot object that can send emails from the given
         email account. The default SMTP server is gmail, but this can be
         changed if desired."""
-        self.gmail_username = gmail_username
-        self.gmail_password = gmail_password
+        self.email_username = email_username
+        self.email_password = email_password
         self.smtp_server = smtp_server
         self.smtp_port = smtp_port
 
@@ -23,7 +23,7 @@ class EmailBot:
         recipients are specified."""
         email_message = EmailMessage()
         email_message['Subject'] = subject
-        email_message['From'] = self.gmail_username
+        email_message['From'] = self.email_username
         email_message['To'] = 'will-be-overwritten'
         email_message.set_content(body)
         # # # #
@@ -31,7 +31,7 @@ class EmailBot:
             server.ehlo()
             server.starttls()
             server.ehlo()
-            server.login(self.gmail_username, self.gmail_password)
+            server.login(self.email_username, self.email_password)
             # Note: You can pass a list to 'To'
             # I chose not to do this to keep recipients mutually blind:
             for recipient in recipients:

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -7,10 +7,10 @@ load_dotenv()
 ##############################################
 ## Secrets
 
-gmailUsername    = os.environ.get('gmailUsername',   '')
-gmailPassword    = os.environ.get('gmailPassword',   '')
-discordBotToken  = os.environ.get('discordBotToken', '')  # Not implemented
-slackBotToken    = os.environ.get('slackBotToken',   '')
+EMAIL_USERNAME    = os.environ.get('EMAIL_USERNAME',   '')
+EMAIL_PASSWORD    = os.environ.get('EMAIL_PASSWORD',   '')
+TOKEN_DISCORD  = os.environ.get('TOKEN_DISCORD', '')  # Not implemented
+TOKEN_SLACK    = os.environ.get('TOKEN_SLACK',   '')
 
-assert gmailUsername != ''
-assert gmailPassword != ''
+assert EMAIL_USERNAME != ''
+assert EMAIL_PASSWORD != ''

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -9,8 +9,8 @@ load_dotenv()
 
 EMAIL_USERNAME  = os.environ.get('EMAIL_USERNAME',   '')
 EMAIL_PASSWORD  = os.environ.get('EMAIL_PASSWORD',   '')
-TOKEN_DISCORD   = os.environ.get('TOKEN_DISCORD', '')  # Not implemented
-TOKEN_SLACK     = os.environ.get('TOKEN_SLACK',   '')
+TOKEN_DISCORD   = os.environ.get('TOKEN_DISCORD',    '')  # Not implemented
+TOKEN_SLACK     = os.environ.get('TOKEN_SLACK',      '')
 
 ## Pre-flight check
 # We assert that the secrets are not empty so that

--- a/tests/test_bot_email.py
+++ b/tests/test_bot_email.py
@@ -36,7 +36,7 @@ def test_send_emails_mock(mock_smtp):
 def test_send_emails_network():
     """Send real emails over a network to a test inbox and check that 
     they were received."""
-    email_bot = EmailBot(c.gmailUsername, c.gmailPassword)
+    email_bot = EmailBot(c.EMAIL_USERNAME, c.EMAIL_PASSWORD)
     # Uses an anonymous email inbox for testing
     recipients = ['nodemonitortest@mailnesia.com']
     subject = str(time.time())


### PR DESCRIPTION
### Description
Capitalized .env variable names

### Changes made
- Changes were made in all files that loaded the email user name and password. 
- Also, any variables that mentioned gmail e.g. `self.gmail_username` were also changed to a more generic name like `self.email_username`

### Testing
Using `TEST=true docker compose up --build`

### Additional comments
n/a
