### PR TITLE
include a default label for nodes with no label info

### DIFF
--- a/node_monitor/node_monitor_helpers/messages.py
+++ b/node_monitor/node_monitor_helpers/messages.py
@@ -24,7 +24,8 @@ def detailnodes(nodes: List[ic_api.Node],
     """Runs detailnode on each node in nodes and returns a string of the
     results, separated by newlines.
     """
-    msgs = [detailnode(node, labels[node.node_id]) for node in nodes]
+    msgs = [detailnode(node, labels.get(node.node_id, 'N/A'))
+            for node in nodes]
     return '\n'.join(msgs)
 
 


### PR DESCRIPTION
Fixes an issue where NodeMonitor will crash if there is no label information for a node

Indexes a dictionary with `.get()` instead of `dict_['item']` syntax.

