### PR TITLE
72 get compromised nodes throws keyerror when a new node comes into existence

### DIFF
--- a/node_monitor/node_monitor_helpers/get_compromised_nodes.py
+++ b/node_monitor/node_monitor_helpers/get_compromised_nodes.py
@@ -45,6 +45,8 @@ def get_compromised_nodes(snapshots: Deque[ic_api.Nodes]) -> List[ic_api.Node]:
     # collect downed nodes
     compromised_nodes = []
     for node_id in ci.keys():
+        # if the node just came online in c, skip it to avoid IndexError
+        if node_id not in ai or node_id not in bi: continue
         node_a = ai[node_id]
         node_b = bi[node_id]
         node_c = ci[node_id]

--- a/tests/test_node_monitor.py
+++ b/tests/test_node_monitor.py
@@ -132,3 +132,24 @@ def test_two_nodes_down():
     assert mock_email_bot.send_emails.call_count == 1
     mock_node_provider_db.reset_mock()
 
+
+def test_one_new_node_online():
+    """Test the case where one new node comes online."""
+    # init
+    mock_email_bot = Mock(spec=EmailBot)
+    nm = NodeMonitor(mock_email_bot, mock_node_provider_db)
+    nm._resync(cached['one_node_removed'])
+    nm._resync(cached['one_node_removed'])
+    nm._resync(cached['control'])
+
+    # test _analyze()
+    nm._analyze()
+    assert len(nm.compromised_nodes) == 0
+    assert len(nm.compromised_nodes_by_provider) == 0
+    assert len(nm.actionables) == 0
+
+    # test broadcast()
+    nm.broadcast()
+    assert mock_email_bot.send_emails.call_count == 0
+    mock_node_provider_db.reset_mock()
+


### PR DESCRIPTION
Fixes #72

## Proposed Changes
- Skip through an iteration in the loop through keys in `c` early, if the key does not exist in `a` or `b`
