### PR TITLE
Implement eventlet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,15 @@ dev:
 
 # Run this with the production gunicorn WSGI Server
 prod:
-	gunicorn -w 1 -b 0.0.0.0:80 node_monitor.__main__:app
+	gunicorn -w 1 -b 0.0.0.0:80 -k eventlet node_monitor.__main__:app
 # We're forced to run this with only one worker because we're instantiating
 # node_monitor in a thread from inside the app. If we had multiple workers,
 # we would have multiple instances of node_monitor running, each sending
 # emails. Because this is a low traffic app, I found it easier to just run
 # one worker, rather than use something like Celery.
+
+# We're using eventlet because otherwise we get timeouts in the default
+# sync worker, which causes gunicorn to timeout and restart the app, 
+# resetting any internal state. See:
+# https://github.com/benoitc/gunicorn/issues/1801#issuecomment-585886471
+# https://stackoverflow.com/questions/15463067/gunicorn-worker-timeout

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,6 @@ prod:
 # We're using eventlet because otherwise we get timeouts in the default
 # sync worker, which causes gunicorn to timeout and restart the app, 
 # resetting any internal state. See:
+# https://docs.gunicorn.org/en/stable/design.html
 # https://github.com/benoitc/gunicorn/issues/1801#issuecomment-585886471
 # https://stackoverflow.com/questions/15463067/gunicorn-worker-timeout

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ dev:
 
 # Run this with the production gunicorn WSGI Server
 prod:
-	gunicorn -w 1 -b 0.0.0.0:80 -k eventlet node_monitor.__main__:app
+	gunicorn -w 1 -b 0.0.0.0:80 --access-logfile gunicornlog.txt -k eventlet node_monitor.__main__:app
 # We're forced to run this with only one worker because we're instantiating
 # node_monitor in a thread from inside the app. If we had multiple workers,
 # we would have multiple instances of node_monitor running, each sending


### PR DESCRIPTION
## Proposed Changes
Runs `gunicorn` with `eventlet` instead of the default sync workers.
Avoids a bug where a hanging blocking execution would cause a timeout and subsequent reset of node-monitor.

