### PR TITLE
95 bugfix/form not hyperlinked

### DIFF
--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -17,6 +17,7 @@ DB_USERNAME     = os.environ.get('DB_USERNAME',     '')
 DB_PASSWORD     = os.environ.get('DB_PASSWORD',     '')
 DB_NAME         = os.environ.get('DB_NAME',         '')
 DB_PORT         = os.environ.get('DB_PORT',         '')
+FEEDBACK_FORM   = os.environ.get('FEEDBACK_FORM',   '')
 
 
 ## Pre-flight check

--- a/node_monitor/load_config.py
+++ b/node_monitor/load_config.py
@@ -7,17 +7,17 @@ load_dotenv()
 ##############################################
 ## Secrets
 
-EMAIL_USERNAME  = os.environ.get('EMAIL_USERNAME',  '')
-EMAIL_PASSWORD  = os.environ.get('EMAIL_PASSWORD',  '')
-TOKEN_DISCORD   = os.environ.get('TOKEN_DISCORD',   '')  # Not implemented
-TOKEN_SLACK     = os.environ.get('TOKEN_SLACK',     '')
-TOKEN_TELEGRAM  = os.environ.get('TOKEN_TELEGRAM',  '')
-DB_HOST         = os.environ.get('DB_HOST',         '')
-DB_USERNAME     = os.environ.get('DB_USERNAME',     '')
-DB_PASSWORD     = os.environ.get('DB_PASSWORD',     '')
-DB_NAME         = os.environ.get('DB_NAME',         '')
-DB_PORT         = os.environ.get('DB_PORT',         '')
-FEEDBACK_FORM   = os.environ.get('FEEDBACK_FORM',   '')
+EMAIL_USERNAME      = os.environ.get('EMAIL_USERNAME',      '')
+EMAIL_PASSWORD      = os.environ.get('EMAIL_PASSWORD',      '')
+TOKEN_DISCORD       = os.environ.get('TOKEN_DISCORD',       '')  # Not implemented
+TOKEN_SLACK         = os.environ.get('TOKEN_SLACK',         '')
+TOKEN_TELEGRAM      = os.environ.get('TOKEN_TELEGRAM',      '')
+DB_HOST             = os.environ.get('DB_HOST',             '')
+DB_USERNAME         = os.environ.get('DB_USERNAME',         '')
+DB_PASSWORD         = os.environ.get('DB_PASSWORD',         '')
+DB_NAME             = os.environ.get('DB_NAME',             '')
+DB_PORT             = os.environ.get('DB_PORT',             '')
+FEEDBACK_FORM_URL   = os.environ.get('FEEDBACK_FORM_URL',   '')
 
 
 ## Pre-flight check

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -109,7 +109,7 @@ class NodeMonitor:
         for node_provider_id, nodes in self.actionables.items():
             preferences = subscribers[node_provider_id]
             subject, message = messages.nodes_down_message(
-                nodes, node_labels, c.FEEDBACK_FORM)
+                nodes, node_labels, c.FEEDBACK_FORM_URL)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]
@@ -145,7 +145,7 @@ class NodeMonitor:
         for node_provider_id, nodes in reportable_nodes.items():
             preferences = subscribers[node_provider_id]
             subject, message = messages.nodes_status_message(
-                nodes, node_labels, c.FEEDBACK_FORM)
+                nodes, node_labels, c.FEEDBACK_FORM_URL)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -12,6 +12,7 @@ from node_monitor.node_provider_db import NodeProviderDB
 from node_monitor.node_monitor_helpers.get_compromised_nodes import \
     get_compromised_nodes
 import node_monitor.node_monitor_helpers.messages as messages
+import node_monitor.load_config as c
 
 Seconds = int
 Principal = str
@@ -107,7 +108,8 @@ class NodeMonitor:
         channels = self.node_provider_db.get_channels_as_dict()
         for node_provider_id, nodes in self.actionables.items():
             preferences = subscribers[node_provider_id]
-            subject, message = messages.nodes_down_message(nodes, node_labels)
+            subject, message = messages.nodes_down_message(
+                nodes, node_labels, c.FEEDBACK_FORM)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]
@@ -142,7 +144,8 @@ class NodeMonitor:
         # - - - - - - - - - - - - - - - - -
         for node_provider_id, nodes in reportable_nodes.items():
             preferences = subscribers[node_provider_id]
-            subject, message = messages.nodes_status_message(nodes, node_labels)
+            subject, message = messages.nodes_status_message(
+                nodes, node_labels, c.FEEDBACK_FORM)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -12,7 +12,6 @@ from node_monitor.node_provider_db import NodeProviderDB
 from node_monitor.node_monitor_helpers.get_compromised_nodes import \
     get_compromised_nodes
 import node_monitor.node_monitor_helpers.messages as messages
-import node_monitor.load_config as c
 
 Seconds = int
 Principal = str
@@ -108,8 +107,7 @@ class NodeMonitor:
         channels = self.node_provider_db.get_channels_as_dict()
         for node_provider_id, nodes in self.actionables.items():
             preferences = subscribers[node_provider_id]
-            subject, message = messages.nodes_down_message(
-                nodes, node_labels, c.FEEDBACK_FORM_URL)
+            subject, message = messages.nodes_down_message(nodes, node_labels)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]
@@ -144,8 +142,7 @@ class NodeMonitor:
         # - - - - - - - - - - - - - - - - -
         for node_provider_id, nodes in reportable_nodes.items():
             preferences = subscribers[node_provider_id]
-            subject, message = messages.nodes_status_message(
-                nodes, node_labels, c.FEEDBACK_FORM_URL)
+            subject, message = messages.nodes_status_message(nodes, node_labels)
             # - - - - - - - - - - - - - - - - -
             if preferences['notify_email'] == True:
                 recipients = email_recipients[node_provider_id]

--- a/node_monitor/node_monitor_helpers/messages.py
+++ b/node_monitor/node_monitor_helpers/messages.py
@@ -54,8 +54,7 @@ def detailnodes(nodes: List[ic_api.Node],
 
 
 def nodes_down_message(nodes: List[ic_api.Node], 
-                       labels: Dict[Principal, str],
-                       feedback_form_url: str) -> Tuple[str, str]:
+                       labels: Dict[Principal, str]) -> Tuple[str, str]:
     """Returns a message that describes the nodes that are down, in the
     format of an email or message for a comprable communication channel.
     """
@@ -76,14 +75,13 @@ def nodes_down_message(nodes: List[ic_api.Node],
         f"\n"
         f"Node Monitor by Aviate Labs\n"
         f"Report Generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback here: {feedback_form_url}\n")
+        f"Help us serve you better! Provide your feedback here: {c.FEEDBACK_FORM_URL}\n")
     return (subject, message)
 
 
 
 def nodes_status_message(nodes: List[ic_api.Node],
-                         labels: Dict[Principal, str],
-                         feedback_form_url: str) -> Tuple[str, str]:
+                         labels: Dict[Principal, str]) -> Tuple[str, str]:
     """Returns a message that describes the status of all nodes, in the
     format of an email or message for a comprable communication channel.
     """
@@ -128,5 +126,5 @@ def nodes_status_message(nodes: List[ic_api.Node],
         f"Thanks for reviewing today's report. We'll be back tomorrow!\n"
         f"Node Monitor by Aviate Labs.\n"
         f"Report generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback here: {feedback_form_url} \n")
+        f"Help us serve you better! Provide your feedback here: {c.FEEDBACK_FORM_URL}\n")
     return (subject, message)

--- a/node_monitor/node_monitor_helpers/messages.py
+++ b/node_monitor/node_monitor_helpers/messages.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Dict, Tuple
 
 import node_monitor.ic_api as ic_api
+import node_monitor.load_config as c
 
 # Forgive me Lord Guido, for I have broken PEP8.
 Principal = str
@@ -53,7 +54,8 @@ def detailnodes(nodes: List[ic_api.Node],
 
 
 def nodes_down_message(nodes: List[ic_api.Node], 
-                       labels: Dict[Principal, str]) -> Tuple[str, str]:
+                       labels: Dict[Principal, str],
+                       feedback_form: str) -> Tuple[str, str]:
     """Returns a message that describes the nodes that are down, in the
     format of an email or message for a comprable communication channel.
     """
@@ -74,13 +76,14 @@ def nodes_down_message(nodes: List[ic_api.Node],
         f"\n"
         f"Node Monitor by Aviate Labs\n"
         f"Report Generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback!\n")
+        f"Help us serve you better! Provide your feedback here: {feedback_form}\n")
     return (subject, message)
 
 
 
 def nodes_status_message(nodes: List[ic_api.Node],
-                         labels: Dict[Principal, str]) -> Tuple[str, str]:
+                         labels: Dict[Principal, str],
+                         feedback_form: str) -> Tuple[str, str]:
     """Returns a message that describes the status of all nodes, in the
     format of an email or message for a comprable communication channel.
     """
@@ -125,5 +128,5 @@ def nodes_status_message(nodes: List[ic_api.Node],
         f"Thanks for reviewing today's report. We'll be back tomorrow!\n"
         f"Node Monitor by Aviate Labs.\n"
         f"Report generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback!\n")
+        f"Help us serve you better! Provide your feedback here: {feedback_form} \n")
     return (subject, message)

--- a/node_monitor/node_monitor_helpers/messages.py
+++ b/node_monitor/node_monitor_helpers/messages.py
@@ -55,7 +55,7 @@ def detailnodes(nodes: List[ic_api.Node],
 
 def nodes_down_message(nodes: List[ic_api.Node], 
                        labels: Dict[Principal, str],
-                       feedback_form: str) -> Tuple[str, str]:
+                       feedback_form_url: str) -> Tuple[str, str]:
     """Returns a message that describes the nodes that are down, in the
     format of an email or message for a comprable communication channel.
     """
@@ -76,14 +76,14 @@ def nodes_down_message(nodes: List[ic_api.Node],
         f"\n"
         f"Node Monitor by Aviate Labs\n"
         f"Report Generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback here: {feedback_form}\n")
+        f"Help us serve you better! Provide your feedback here: {feedback_form_url}\n")
     return (subject, message)
 
 
 
 def nodes_status_message(nodes: List[ic_api.Node],
                          labels: Dict[Principal, str],
-                         feedback_form: str) -> Tuple[str, str]:
+                         feedback_form_url: str) -> Tuple[str, str]:
     """Returns a message that describes the status of all nodes, in the
     format of an email or message for a comprable communication channel.
     """
@@ -128,5 +128,5 @@ def nodes_status_message(nodes: List[ic_api.Node],
         f"Thanks for reviewing today's report. We'll be back tomorrow!\n"
         f"Node Monitor by Aviate Labs.\n"
         f"Report generated: {datetime.utcnow().isoformat()} UTC\n"
-        f"Help us serve you better! Provide your feedback here: {feedback_form} \n")
+        f"Help us serve you better! Provide your feedback here: {feedback_form_url} \n")
     return (subject, message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import node_monitor.ic_api as ic_api
 ##   --db is a custom flag to test CRUD operations on the database
 ## example: pytest -s --send_emails tests/test_bot_email.py
 ## example: pytest -s --send_slack tests/test_bot_slack.py
+## example: pytest -s --send_telegram tests/test_bot_telegram.py
 ## example: pytest -s --db tests/test_node_provider_db.py
 
 

--- a/tests/test_bot_email.py
+++ b/tests/test_bot_email.py
@@ -55,23 +55,25 @@ def test_send_emails_network():
         subnet_id = 'fake_subnet_id',
     )
     fakelabel = {'fake_node_id': 'fake_label'}
-    fakeurl = 'https://forms.gle/thisisfake'
 
     ## Init the authenticated email bot instance
     email_bot = EmailBot(c.EMAIL_USERNAME, c.EMAIL_PASSWORD)
 
-    ## Set paramaters (uses an anonymous email inbox for testing)
-    ## Send out nodes_down_message and nodes_status_message. We test both.
-    ## We append time to the subject to act as an identifier for the test.
+    ## Set recipient (we use an anonymous email inbox for testing)
     recipients = ['nodemonitortest@mailnesia.com']
-    subject1, message1 = messages.nodes_down_message(
-        [fakenode], fakelabel, fakeurl)
-    subject1 = str(f'{time.time()} - {subject1}')
-    email_bot.send_emails(recipients, subject1, message1)
 
-    subject2, message2 = messages.nodes_status_message(
-        [fakenode], fakelabel, fakeurl)
+    ## Create the messages. We use unittest.mock.patch to remove the private URL.
+    with patch.object(c, 'FEEDBACK_FORM_URL', 'https://url-has-been-redacted.ninja'):
+        subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
+        subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
+
+    ## Append the time to the subject to act as an identifier for the test,
+    ## making it easy to do a regex search to validate the email.
+    subject1 = str(f'{time.time()} - {subject1}')
     subject2 = str(f'{time.time()} - {subject2}')
+
+    ## Send both nodes_down_message and nodes_status_message as emails.
+    email_bot.send_emails(recipients, subject1, message1)
     email_bot.send_emails(recipients, subject2, message2)
 
     ## Automatically check the email inbox

--- a/tests/test_bot_email.py
+++ b/tests/test_bot_email.py
@@ -55,6 +55,7 @@ def test_send_emails_network():
         subnet_id = 'fake_subnet_id',
     )
     fakelabel = {'fake_node_id': 'fake_label'}
+    fakeurl = 'https://forms.gle/thisisfake'
 
     ## Init the authenticated email bot instance
     email_bot = EmailBot(c.EMAIL_USERNAME, c.EMAIL_PASSWORD)
@@ -63,11 +64,13 @@ def test_send_emails_network():
     ## Send out nodes_down_message and nodes_status_message. We test both.
     ## We append time to the subject to act as an identifier for the test.
     recipients = ['nodemonitortest@mailnesia.com']
-    subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
+    subject1, message1 = messages.nodes_down_message(
+        [fakenode], fakelabel, fakeurl)
     subject1 = str(f'{time.time()} - {subject1}')
     email_bot.send_emails(recipients, subject1, message1)
 
-    subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
+    subject2, message2 = messages.nodes_status_message(
+        [fakenode], fakelabel, fakeurl)
     subject2 = str(f'{time.time()} - {subject2}')
     email_bot.send_emails(recipients, subject2, message2)
 

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -3,8 +3,6 @@ from unittest.mock import patch
 
 from node_monitor.bot_slack import SlackBot
 import node_monitor.load_config as c
-import node_monitor.node_monitor_helpers.messages as messages
-import node_monitor.ic_api as ic_api
 
 
 @patch("slack_sdk.WebClient")

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -26,33 +26,12 @@ def test_send_message(mock_web_client):
 def test_send_message_slack():
     """Send a real test message to a Slack workspace"""
     slack_bot = SlackBot(c.TOKEN_SLACK)
-
-    ## Create a fake node model
-    fakenode = ic_api.Node(
-        dc_id = 'fake_dc_id',
-        dc_name = 'fake_dc_name',
-        node_id = 'fake_node_id',
-        node_operator_id = 'fake_node_operator_id',
-        node_provider_id = 'fake_node_provider_id',
-        node_provider_name = 'fake_node_provider_name',
-        owner = 'fake_owner',
-        region = 'fake_region',
-        status = 'DOWN',
-        subnet_id = 'fake_subnet_id',
-    )
-    fakelabel = {'fake_node_id': 'fake_label'}
-    
     slack_channel_name = "node-monitor"
-    with patch.object(c, 'FEEDBACK_FORM_URL', 'https://url-has-been-redacted.ninja'):
-        subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
-        subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
+    message = "🔬 This is a test message from Node Monitor"
 
     ## SlackBot.send_message() normally returns an error without raising 
     ## an exception to prevent NodeMonitor from crashing if the message 
     ## fails to send. We make sure to raise it here to purposely fail the test.
-    err1 = slack_bot.send_message(slack_channel_name, message1)
-    err2 = slack_bot.send_message(slack_channel_name, message2)
-    if err1 is not None:
-        raise err1
-    if err2 is not None:
-        raise err2
+    err = slack_bot.send_message(slack_channel_name, message)
+    if err is not None:
+        raise err

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -41,17 +41,15 @@ def test_send_message_slack():
         subnet_id = 'fake_subnet_id',
     )
     fakelabel = {'fake_node_id': 'fake_label'}
-    fakeurl = 'https://forms.gle/thisisfake'
     
     slack_channel_name = "node-monitor"
-    subject1, message1 = messages.nodes_down_message(
-        [fakenode], fakelabel, fakeurl)
-    subject2, message2 = messages.nodes_status_message(
-        [fakenode], fakelabel, fakeurl)
+    with patch.object(c, 'FEEDBACK_FORM_URL', 'https://url-has-been-redacted.ninja'):
+        subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
+        subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
 
-    # SlackBot.send_message() returns an error without raising an exception
-    # to prevent NodeMonitor from crashing if the message fails to send.
-    # Instead, we raise it here.
+    ## SlackBot.send_message() normally returns an error without raising 
+    ## an exception to prevent NodeMonitor from crashing if the message 
+    ## fails to send. We make sure to raise it here to purposely fail the test.
     err1 = slack_bot.send_message(slack_channel_name, message1)
     err2 = slack_bot.send_message(slack_channel_name, message2)
     if err1 is not None:

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -27,30 +27,9 @@ def test_send_message(mock_get):
 def test_send_live_message():
     telegram_bot = TelegramBot(c.TOKEN_TELEGRAM)
     chat_id = "-1001925583150"  
+    message = "🔬 This is a test message from Node Monitor"
 
-    ## Create a fake node model
-    fakenode = ic_api.Node(
-        dc_id = 'fake_dc_id',
-        dc_name = 'fake_dc_name',
-        node_id = 'fake_node_id',
-        node_operator_id = 'fake_node_operator_id',
-        node_provider_id = 'fake_node_provider_id',
-        node_provider_name = 'fake_node_provider_name',
-        owner = 'fake_owner',
-        region = 'fake_region',
-        status = 'DOWN',
-        subnet_id = 'fake_subnet_id',
-    )
-    fakelabel = {'fake_node_id': 'fake_label'}
-
-    with patch.object(c, 'FEEDBACK_FORM_URL', 'https://url-has-been-redacted.ninja'):
-        subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
-        subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
-
-    err1 = telegram_bot.send_message(chat_id, message1)
-    err2 = telegram_bot.send_message(chat_id, message2)
-    if err1 is not None:
-        raise err1
-    if err2 is not None:
-        raise err2
+    err = telegram_bot.send_message(chat_id, message)
+    if err is not None:
+        raise err
 

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -2,8 +2,6 @@ import pytest
 from unittest.mock import patch
 
 import node_monitor.load_config as c
-import node_monitor.node_monitor_helpers.messages as messages
-import node_monitor.ic_api as ic_api
 from node_monitor.bot_telegram import TelegramBot
 
 @patch("requests.get")

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -2,6 +2,8 @@ import pytest
 from unittest.mock import patch
 
 import node_monitor.load_config as c
+import node_monitor.node_monitor_helpers.messages as messages
+import node_monitor.ic_api as ic_api
 from node_monitor.bot_telegram import TelegramBot
 
 @patch("requests.get")
@@ -25,8 +27,32 @@ def test_send_message(mock_get):
 def test_send_live_message():
     telegram_bot = TelegramBot(c.TOKEN_TELEGRAM)
     chat_id = "-1001925583150"  
-    message = "Test message"
 
-    err = telegram_bot.send_message(chat_id, message)
-    if err is not None:
-        raise err
+    ## Create a fake node model
+    fakenode = ic_api.Node(
+        dc_id = 'fake_dc_id',
+        dc_name = 'fake_dc_name',
+        node_id = 'fake_node_id',
+        node_operator_id = 'fake_node_operator_id',
+        node_provider_id = 'fake_node_provider_id',
+        node_provider_name = 'fake_node_provider_name',
+        owner = 'fake_owner',
+        region = 'fake_region',
+        status = 'DOWN',
+        subnet_id = 'fake_subnet_id',
+    )
+    fakelabel = {'fake_node_id': 'fake_label'}
+    fakeurl = 'https://forms.gle/thisisfake'
+    
+    subject1, message1 = messages.nodes_down_message(
+        [fakenode], fakelabel, fakeurl)
+    subject2, message2 = messages.nodes_status_message(
+        [fakenode], fakelabel, fakeurl)
+
+    err1 = telegram_bot.send_message(chat_id, message1)
+    err2 = telegram_bot.send_message(chat_id, message2)
+    if err1 is not None:
+        raise err1
+    if err2 is not None:
+        raise err2
+

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -42,12 +42,10 @@ def test_send_live_message():
         subnet_id = 'fake_subnet_id',
     )
     fakelabel = {'fake_node_id': 'fake_label'}
-    fakeurl = 'https://forms.gle/thisisfake'
-    
-    subject1, message1 = messages.nodes_down_message(
-        [fakenode], fakelabel, fakeurl)
-    subject2, message2 = messages.nodes_status_message(
-        [fakenode], fakelabel, fakeurl)
+
+    with patch.object(c, 'FEEDBACK_FORM_URL', 'https://url-has-been-redacted.ninja'):
+        subject1, message1 = messages.nodes_down_message([fakenode], fakelabel)
+        subject2, message2 = messages.nodes_status_message([fakenode], fakelabel)
 
     err1 = telegram_bot.send_message(chat_id, message1)
     err2 = telegram_bot.send_message(chat_id, message2)


### PR DESCRIPTION
Fixes #95 

### Description
Include a link to a feedback form in all messages sent from Node Monitor.

### Changes made
- Load form URL from .env and pass as an argument to functions in `messages.py`.
- Update `test_bot_telegram` and `test_bot_slack` to use message templates when sending live messages during testing.

### Testing
- Ran entire testing suite and all checks passed.

### Additional comments
n/a