### PR TITLE
bind the logs inside docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 *~
 .vscode/
 
-# logs
-logs/
 
 # misc
 *.csv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,6 @@ services:
       - type: bind
         source: .env
         target: /app/.env
+      - type: bind
+        source: ./logs/
+        target: /app/logs/

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,11 @@
+# This `logs/` folder needs to exist for docker to be able to bind to it.
+# We use this gitignore file to commit the folder to the repo, so it exists
+# in our github workflow and can be run with CI. 
+# Empty directories are not tracked by default in git.
+
+
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+


### PR DESCRIPTION
Fixes an issue where the logs could not be written to the `logs/` directory in the docker container. I think the file path was interpreted wrong:

```
gunicorn -w 1 -b 0.0.0.0:80 --access-logfile=logs/gunicorn_access.log --error-logfile=logs/gunicorn_error.log -k eventlet node_monitor.__main__:app

Error: Error: 'logs/gunicorn_error.log' isn't writable [FileNotFoundError(2, 'No such file or directory')]
```

Docker containers are supposed to be stateless, so we had two options:
1. Output all logs to stdout so they get picked up by docker directly.
2. Bind the `/app/logs` directory in the container to the `logs/` directory on the machine.


I opted for (2) because it allows us to keep our separate logfiles:
- `gunicorn_access.log`
- `gunicorn_error.log`
- `node_monitor.log`