### PR TITLE
128-feature/show-subject-in-slack-and-telegram

### DIFF
--- a/node_monitor/bot_slack.py
+++ b/node_monitor/bot_slack.py
@@ -28,13 +28,13 @@ class SlackBot:
     
 
     def send_messages(
-            self, slack_channel_names: List[str],
+            self, slack_channel_names: List[str], subject: str,
             message: str) -> None | SlackApiError:
         """Send a message to multiple Slack channels."""
         # Propagate the last error that occurs
         err = None
         for slack_channel_name in slack_channel_names:
-            this_err = self.send_message(slack_channel_name, message)
+            this_err = self.send_message(slack_channel_name, subject, message)
             if this_err is not None:
                 err = this_err
         return err

--- a/node_monitor/bot_slack.py
+++ b/node_monitor/bot_slack.py
@@ -6,16 +6,16 @@ class SlackBot:
 
     def __init__(self, slack_token: str) -> None:
         self.client = slack_sdk.WebClient(token=slack_token)
+        
 
     def send_message(
-            self, slack_channel_name: str, subject: str,
+            self, slack_channel_name: str,
             message: str) -> None | SlackApiError:
         """Send a message to a single Slack channel."""
-        dispatch = f"{subject}\n\n{message}"
         try:
             self.client.chat_postMessage(
                 channel=slack_channel_name,
-                text=dispatch)
+                text=message)
         except SlackApiError as e:
             # You will get a SlackApiError if "ok" is False
             # If ok is False, e.response["error"] contains a
@@ -28,13 +28,13 @@ class SlackBot:
     
 
     def send_messages(
-            self, slack_channel_names: List[str], subject: str,
+            self, slack_channel_names: List[str],
             message: str) -> None | SlackApiError:
         """Send a message to multiple Slack channels."""
         # Propagate the last error that occurs
         err = None
         for slack_channel_name in slack_channel_names:
-            this_err = self.send_message(slack_channel_name, subject, message)
+            this_err = self.send_message(slack_channel_name, message)
             if this_err is not None:
                 err = this_err
         return err

--- a/node_monitor/bot_slack.py
+++ b/node_monitor/bot_slack.py
@@ -8,13 +8,14 @@ class SlackBot:
         self.client = slack_sdk.WebClient(token=slack_token)
 
     def send_message(
-            self, slack_channel_name: str,
+            self, slack_channel_name: str, subject: str,
             message: str) -> None | SlackApiError:
         """Send a message to a single Slack channel."""
+        dispatch = f"{subject}\n\n{message}"
         try:
             self.client.chat_postMessage(
                 channel=slack_channel_name,
-                text=message)
+                text=dispatch)
         except SlackApiError as e:
             # You will get a SlackApiError if "ok" is False
             # If ok is False, e.response["error"] contains a

--- a/node_monitor/bot_telegram.py
+++ b/node_monitor/bot_telegram.py
@@ -30,13 +30,13 @@ class TelegramBot:
     
 
     def send_messages(
-            self, chat_ids: List[str], message: str
+            self, chat_ids: List[str], subject: str, message: str
             ) -> None | requests.exceptions.HTTPError:
         """Send a message to multiple Telegram chats."""
         # Propagate the last error that occurs
         err = None
         for chat_id in chat_ids:
-            this_err = self.send_message(chat_id, message)
+            this_err = self.send_message(chat_id, subject, message)
             if this_err is not None:
                 err = this_err
         return err

--- a/node_monitor/bot_telegram.py
+++ b/node_monitor/bot_telegram.py
@@ -9,11 +9,12 @@ class TelegramBot:
 
 
     def send_message(
-            self, chat_id: str, message: str
+            self, chat_id: str, subject: str, message: str
         ) -> None | requests.exceptions.HTTPError:
         """Send a message to a single Telegram chat."""
+        dispatch = f"{subject}\n\n{message}"
         max_message_length = 4096
-        message_parts = textwrap.wrap(message, width=max_message_length)
+        message_parts = textwrap.wrap(dispatch, width=max_message_length)
 
         try:
             for part in message_parts:

--- a/node_monitor/bot_telegram.py
+++ b/node_monitor/bot_telegram.py
@@ -9,12 +9,15 @@ class TelegramBot:
 
 
     def send_message(
-            self, chat_id: str, subject: str, message: str
+            self, chat_id: str, message: str
         ) -> None | requests.exceptions.HTTPError:
         """Send a message to a single Telegram chat."""
-        dispatch = f"{subject}\n\n{message}"
         max_message_length = 4096
-        message_parts = [dispatch[i:i + max_message_length] for i in range(0, len(dispatch), max_message_length)]
+
+        # TODO: use itertools.batched here when python version is updated to >=3.12.
+        message_parts = [
+            message[i:i + max_message_length] 
+            for i in range(0, len(message), max_message_length)]
 
         try:
             for part in message_parts:
@@ -30,13 +33,13 @@ class TelegramBot:
     
 
     def send_messages(
-            self, chat_ids: List[str], subject: str, message: str
+            self, chat_ids: List[str], message: str
             ) -> None | requests.exceptions.HTTPError:
         """Send a message to multiple Telegram chats."""
         # Propagate the last error that occurs
         err = None
         for chat_id in chat_ids:
-            this_err = self.send_message(chat_id, subject, message)
+            this_err = self.send_message(chat_id, message)
             if this_err is not None:
                 err = this_err
         return err

--- a/node_monitor/bot_telegram.py
+++ b/node_monitor/bot_telegram.py
@@ -14,7 +14,7 @@ class TelegramBot:
         """Send a message to a single Telegram chat."""
         dispatch = f"{subject}\n\n{message}"
         max_message_length = 4096
-        message_parts = textwrap.wrap(dispatch, width=max_message_length)
+        message_parts = [dispatch[i:i + max_message_length] for i in range(0, len(dispatch), max_message_length)]
 
         try:
             for part in message_parts:

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -117,6 +117,7 @@ class NodeMonitor:
             """Broadcasts a generic message to a subscriber through their
             selected communication channel(s)."""
             preferences = subscribers[node_provider_id]
+            dispatch = f"{subject}\n\n{message}"
             if preferences['notify_email'] == True:
                 recipients = email_recipients.get(node_provider_id, [])
                 if recipients:
@@ -125,12 +126,12 @@ class NodeMonitor:
                 if self.slack_bot:
                     channels = slack_channels.get(node_provider_id, [])
                     if channels:
-                        err1 = self.slack_bot.send_messages(channels, subject, message)
+                        err1 = self.slack_bot.send_messages(channels, dispatch)
             if preferences['notify_telegram'] == True:
                 if self.telegram_bot:
                     chats = telegram_chats.get(node_provider_id, [])
                     if chats:
-                        err2 = self.telegram_bot.send_messages(chats, subject, message)
+                        err2 = self.telegram_bot.send_messages(chats, dispatch)
             return None
         
         return broadcaster

--- a/node_monitor/node_monitor.py
+++ b/node_monitor/node_monitor.py
@@ -125,12 +125,12 @@ class NodeMonitor:
                 if self.slack_bot:
                     channels = slack_channels.get(node_provider_id, [])
                     if channels:
-                        err1 = self.slack_bot.send_messages(channels, message)
+                        err1 = self.slack_bot.send_messages(channels, subject, message)
             if preferences['notify_telegram'] == True:
                 if self.telegram_bot:
                     chats = telegram_chats.get(node_provider_id, [])
                     if chats:
-                        err2 = self.telegram_bot.send_messages(chats, message)
+                        err2 = self.telegram_bot.send_messages(chats, subject, message)
             return None
         
         return broadcaster

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,23 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_live_telegram)
 
 
+@pytest.fixture
+def fake_data():
+    fakenode = ic_api.Node(
+        dc_id='fake_dc_id',
+        dc_name='fake_dc_name',
+        node_id='fake_node_id',
+        node_operator_id='fake_node_operator_id',
+        node_provider_id='fake_node_provider_id',
+        node_provider_name='fake_node_provider_name',
+        owner='fake_owner',
+        region='fake_region',
+        status='DOWN',
+        subnet_id='fake_subnet_id',
+    )
+    fakelabel = {'fake_node_id': 'fake_label'}
+    return fakenode, fakelabel
+
 
 ## Create mock data for testing
 ## Data was pulled from the ic-api using cURL and stored in json files.

--- a/tests/test_bot_email.py
+++ b/tests/test_bot_email.py
@@ -7,7 +7,8 @@ import re
 from node_monitor.bot_email import EmailBot
 import node_monitor.load_config as c
 import node_monitor.node_monitor_helpers.messages as messages
-import node_monitor.ic_api as ic_api
+from tests.conftest import fake_data
+
 
 # This test sends emails by default
 # Usage to disable live email sending:
@@ -37,24 +38,12 @@ def test_send_emails_mock(mock_smtp):
 
 
 @pytest.mark.live_email
-def test_send_emails_network():
+def test_send_emails_network(fake_data):
     """Send real emails over a network to a test inbox and check that 
     they were received."""
 
-    ## Create a fake node model
-    fakenode = ic_api.Node(
-        dc_id = 'fake_dc_id',
-        dc_name = 'fake_dc_name',
-        node_id = 'fake_node_id',
-        node_operator_id = 'fake_node_operator_id',
-        node_provider_id = 'fake_node_provider_id',
-        node_provider_name = 'fake_node_provider_name',
-        owner = 'fake_owner',
-        region = 'fake_region',
-        status = 'DOWN',
-        subnet_id = 'fake_subnet_id',
-    )
-    fakelabel = {'fake_node_id': 'fake_label'}
+    ## Generate fake node and label
+    fakenode, fakelabel = fake_data
 
     ## Init the authenticated email bot instance
     email_bot = EmailBot(c.EMAIL_USERNAME, c.EMAIL_PASSWORD)

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -14,9 +14,10 @@ def test_send_message(mock_web_client):
     expected_channel = "#node-monitor"
     expected_subject = "Subject message"
     expected_message = "Hello, Slack!"
+    dispatch = f"{expected_subject}\n\n{expected_message}"
 
     slack_bot = SlackBot(c.TOKEN_SLACK)
-    slack_bot.send_message(expected_channel, expected_subject, expected_message)
+    slack_bot.send_message(expected_channel, dispatch)
 
     mock_client.chat_postMessage.assert_called_once_with(
         channel=expected_channel,
@@ -31,10 +32,11 @@ def test_send_message_slack(fake_data):
     slack_channel_name = "node-monitor"
 
     subject, message = messages.nodes_compromised_message([fakenode], fakelabel)
+    dispatch = f"{subject}\n\n{message}"
 
     ## SlackBot.send_message() normally returns an error without raising 
     ## an exception to prevent NodeMonitor from crashing if the message 
     ## fails to send. We make sure to raise it here to purposely fail the test.
-    err = slack_bot.send_message(slack_channel_name, subject, message)
+    err = slack_bot.send_message(slack_channel_name, dispatch)
     if err is not None:
         raise err

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -2,6 +2,8 @@ import pytest
 from unittest.mock import patch
 
 from node_monitor.bot_slack import SlackBot
+import node_monitor.node_monitor_helpers.messages as messages
+import node_monitor.ic_api as ic_api
 import node_monitor.load_config as c
 
 
@@ -10,26 +12,41 @@ def test_send_message(mock_web_client):
     mock_client = mock_web_client.return_value
 
     expected_channel = "#node-monitor"
+    expected_subject = "Subject message"
     expected_message = "Hello, Slack!"
 
     slack_bot = SlackBot(c.TOKEN_SLACK)
-    slack_bot.send_message(expected_channel, expected_message)
+    slack_bot.send_message(expected_channel, expected_subject, expected_message)
 
     mock_client.chat_postMessage.assert_called_once_with(
         channel=expected_channel,
-        text=expected_message)
+        text=f"{expected_subject}\n\n{expected_message}")
 
 
 @pytest.mark.live_slack
 def test_send_message_slack():
     """Send a real test message to a Slack workspace"""
+    fakenode = ic_api.Node(
+        dc_id = 'fake_dc_id',
+        dc_name = 'fake_dc_name',
+        node_id = 'fake_node_id',
+        node_operator_id = 'fake_node_operator_id',
+        node_provider_id = 'fake_node_provider_id',
+        node_provider_name = 'fake_node_provider_name',
+        owner = 'fake_owner',
+        region = 'fake_region',
+        status = 'DOWN',
+        subnet_id = 'fake_subnet_id',
+    )
+    fakelabel = {'fake_node_id': 'fake_label'}
     slack_bot = SlackBot(c.TOKEN_SLACK)
     slack_channel_name = "node-monitor"
-    message = "🔬 This is a test message from Node Monitor"
+
+    subject, message = messages.nodes_compromised_message([fakenode], fakelabel)
 
     ## SlackBot.send_message() normally returns an error without raising 
     ## an exception to prevent NodeMonitor from crashing if the message 
     ## fails to send. We make sure to raise it here to purposely fail the test.
-    err = slack_bot.send_message(slack_channel_name, message)
+    err = slack_bot.send_message(slack_channel_name, subject, message)
     if err is not None:
         raise err

--- a/tests/test_bot_slack.py
+++ b/tests/test_bot_slack.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 
 from node_monitor.bot_slack import SlackBot
 import node_monitor.node_monitor_helpers.messages as messages
-import node_monitor.ic_api as ic_api
 import node_monitor.load_config as c
+from tests.conftest import fake_data
 
 
 @patch("slack_sdk.WebClient")
@@ -24,21 +24,9 @@ def test_send_message(mock_web_client):
 
 
 @pytest.mark.live_slack
-def test_send_message_slack():
+def test_send_message_slack(fake_data):
     """Send a real test message to a Slack workspace"""
-    fakenode = ic_api.Node(
-        dc_id = 'fake_dc_id',
-        dc_name = 'fake_dc_name',
-        node_id = 'fake_node_id',
-        node_operator_id = 'fake_node_operator_id',
-        node_provider_id = 'fake_node_provider_id',
-        node_provider_name = 'fake_node_provider_name',
-        owner = 'fake_owner',
-        region = 'fake_region',
-        status = 'DOWN',
-        subnet_id = 'fake_subnet_id',
-    )
-    fakelabel = {'fake_node_id': 'fake_label'}
+    fakenode, fakelabel = fake_data
     slack_bot = SlackBot(c.TOKEN_SLACK)
     slack_channel_name = "node-monitor"
 

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -15,7 +15,7 @@ def test_send_message(mock_post):
     message = "Test message"
     payload = {
         "chat_id": chat_id,
-        "text": f"{subject}  {message}"
+        "text": f"{subject}\n\n{message}"
     }
     mock_response = mock_post.return_value
     mock_response.raise_for_status.return_value = None

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -2,21 +2,25 @@ import pytest
 from unittest.mock import patch
 
 import node_monitor.load_config as c
+import node_monitor.node_monitor_helpers.messages as messages
 from node_monitor.bot_telegram import TelegramBot
+import node_monitor.ic_api as ic_api
+
 
 @patch("requests.post")
 def test_send_message(mock_post):
     telegram_bot = TelegramBot(c.TOKEN_TELEGRAM)
     chat_id = "1234567890"
+    subject = "Test subject"
     message = "Test message"
     payload = {
         "chat_id": chat_id,
-        "text": message
+        "text": f"{subject}  {message}"
     }
     mock_response = mock_post.return_value
     mock_response.raise_for_status.return_value = None
 
-    telegram_bot.send_message(chat_id, message)
+    telegram_bot.send_message(chat_id, subject, message)
 
     mock_post.assert_called_once_with(
         f"https://api.telegram.org/bot{telegram_bot.telegram_token}/sendMessage",
@@ -30,8 +34,23 @@ def test_send_message(mock_post):
 def test_send_live_message():
     telegram_bot = TelegramBot(c.TOKEN_TELEGRAM)
     chat_id = "-1001925583150"  
-    message = "🔬 This is a test message from Node Monitor"
 
-    err = telegram_bot.send_message(chat_id, message)
+    fakenode = ic_api.Node(
+        dc_id = 'fake_dc_id',
+        dc_name = 'fake_dc_name',
+        node_id = 'fake_node_id',
+        node_operator_id = 'fake_node_operator_id',
+        node_provider_id = 'fake_node_provider_id',
+        node_provider_name = 'fake_node_provider_name',
+        owner = 'fake_owner',
+        region = 'fake_region',
+        status = 'DOWN',
+        subnet_id = 'fake_subnet_id',
+    )
+    fakelabel = {'fake_node_id': 'fake_label'}
+
+    subject, message = messages.nodes_compromised_message([fakenode], fakelabel)
+
+    err = telegram_bot.send_message(chat_id, subject, message)
     if err is not None:
         raise err

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import node_monitor.load_config as c
 import node_monitor.node_monitor_helpers.messages as messages
 from node_monitor.bot_telegram import TelegramBot
-import node_monitor.ic_api as ic_api
+from tests.conftest import fake_data
 
 
 @patch("requests.post")
@@ -31,23 +31,11 @@ def test_send_message(mock_post):
 
 
 @pytest.mark.live_telegram
-def test_send_live_message():
+def test_send_live_message(fake_data):
+    """Send a real test message to a Telegram channel"""
+    fakenode, fakelabel = fake_data
     telegram_bot = TelegramBot(c.TOKEN_TELEGRAM)
     chat_id = "-1001925583150"  
-
-    fakenode = ic_api.Node(
-        dc_id = 'fake_dc_id',
-        dc_name = 'fake_dc_name',
-        node_id = 'fake_node_id',
-        node_operator_id = 'fake_node_operator_id',
-        node_provider_id = 'fake_node_provider_id',
-        node_provider_name = 'fake_node_provider_name',
-        owner = 'fake_owner',
-        region = 'fake_region',
-        status = 'DOWN',
-        subnet_id = 'fake_subnet_id',
-    )
-    fakelabel = {'fake_node_id': 'fake_label'}
 
     subject, message = messages.nodes_compromised_message([fakenode], fakelabel)
 

--- a/tests/test_bot_telegram.py
+++ b/tests/test_bot_telegram.py
@@ -13,6 +13,7 @@ def test_send_message(mock_post):
     chat_id = "1234567890"
     subject = "Test subject"
     message = "Test message"
+    dispatch = f"{subject}\n\n{message}"
     payload = {
         "chat_id": chat_id,
         "text": f"{subject}\n\n{message}"
@@ -20,7 +21,7 @@ def test_send_message(mock_post):
     mock_response = mock_post.return_value
     mock_response.raise_for_status.return_value = None
 
-    telegram_bot.send_message(chat_id, subject, message)
+    telegram_bot.send_message(chat_id, dispatch)
 
     mock_post.assert_called_once_with(
         f"https://api.telegram.org/bot{telegram_bot.telegram_token}/sendMessage",
@@ -38,7 +39,8 @@ def test_send_live_message(fake_data):
     chat_id = "-1001925583150"  
 
     subject, message = messages.nodes_compromised_message([fakenode], fakelabel)
+    dispatch = f"{subject}\n\n{message}"
 
-    err = telegram_bot.send_message(chat_id, subject, message)
+    err = telegram_bot.send_message(chat_id, dispatch)
     if err is not None:
         raise err


### PR DESCRIPTION
### Description
Fixes #128 

### Changes made
- Add `subject` argument to `send_message` functions in both `bot_slack.py` and `bot_telegram.py`. 

### Testing
- Live messages now send a node down message. This is so that our tests can verify that any changes we make do not affect the formatting of the messages on either platform. 

### Additional comments
- by merging this PR, the format on telegram messages will also be corrected